### PR TITLE
JCF: DUNE-DAQ/daq-deliverables#73: since the fddetdataformats Python …

### DIFF
--- a/python/fddetdataformats/__init__.py
+++ b/python/fddetdataformats/__init__.py
@@ -1,1 +1,2 @@
 from ._daq_fddetdataformats_py import *
+import detdataformats


### PR DESCRIPTION
…module uses detdataformats' DAQEthHeader class (see WIBEthFrame.get_daqheader), make sure importing fddetdataformats also imports the detdataformats Python module