### PR TITLE
Add new CRT data formats for np02 crt systems

### DIFF
--- a/include/fddetdataformats/CRTBernFrame.hpp
+++ b/include/fddetdataformats/CRTBernFrame.hpp
@@ -1,0 +1,211 @@
+/**
+ * @file CRTBernFrame.hpp
+ *
+ * Contains declaration of CRTBernFrame, a class for accessing/holding raw CRT data from the 'Bern' panels ProtoDUNE-II VD
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+#ifndef FDDETDATAFORMATS_INCLUDE_FDDETDATAFORMATS_CRTBERNFRAME_HPP_
+#define FDDETDATAFORMATS_INCLUDE_FDDETDATAFORMATS_CRTBERNFRAME_HPP_
+
+#include "detdataformats/DAQEthHeader.hpp"
+
+#include <algorithm> // For std::min
+#include <cassert>   // For assert()
+#include <cstdint>   // For uint32_t etc
+#include <cstdio>
+#include <cstdlib>
+#include <stdexcept> // For std::out_of_range
+
+namespace dunedaq::fddetdataformats {
+
+/**
+ *  @brief Class for accessing/holding raw CRT data from the 'Bern' panels ProtoDUNE-II VD
+ *
+ */
+    class CRTBernFrame
+    {
+    public:
+        // ===============================================================
+        // Preliminaries
+        // ===============================================================
+
+        // The definition of the format is in terms of 64-bit words
+        typedef uint64_t word_t; // NOLINT
+
+        static constexpr int      s_num_channels = 32;
+        static constexpr uint64_t s_DTS_ticks_per_second = 62'500'000;
+        static constexpr uint64_t s_ns_per_DTS_tick = 16;
+
+        static constexpr int s_bits_per_adc = 16;
+        static constexpr int s_bits_per_word = 8 * sizeof(word_t);
+        static constexpr int s_num_adcs = 64;
+
+        struct CRTBernData
+        {
+            uint16_t flags     = 0;
+            uint16_t lostcpu   = 0;
+            uint16_t lostfpga  = 0;
+            uint32_t ts0       = 0;
+            uint32_t ts1       = 0;
+            uint16_t adc[32]   = {0};
+            uint32_t coinc      = 0;
+        };
+
+        // ===============================================================
+        // Data members
+        // ===============================================================
+        detdataformats::DAQEthHeader daq_header;
+        uint16_t mac5;
+        CRTBernData data;
+
+        // ===============================================================
+        // Accessors
+        // ===============================================================
+
+        /**
+         * @brief Get the adc value for channel i_ch
+         */
+        uint16_t get_adc(int i_ch) const // NOLINT(build/unsigned)
+        {
+            if (i_ch < 0 || i_ch >= s_num_channels)
+                throw std::out_of_range("ADC channel index out of range");
+
+            return data.adc[i_ch];
+        }
+
+        /**
+         * @brief Set the adc value for channel i_ch to @p val
+         */
+        void set_adc(int i_ch, uint16_t val) // NOLINT(build/unsigned)
+        {
+            if (i_ch < 0 || i_ch >= s_num_channels)
+                throw std::out_of_range("ADC channel index out of range");
+
+            data.adc[i_ch]=val;
+        }
+
+        /** @brief Get the starting 64-bit timestamp of the frame
+         */
+        uint64_t get_timestamp() const // NOLINT(build/unsigned)
+        {
+            return daq_header.get_timestamp() ; // NOLINT(build/unsigned)
+        }
+
+        /** @brief Set the starting 64-bit timestamp of the frame
+         *  also set the underlying ts0 to be consistent
+         */
+        void set_timestamp(const uint64_t new_timestamp) // NOLINT(build/unsigned)
+        {
+            daq_header.timestamp = new_timestamp;
+            data.ts0 = (new_timestamp % s_DTS_ticks_per_second) * s_ns_per_DTS_tick;
+        }
+
+        /** @brief Get the MAC5 identifier of the frame
+         */
+        uint16_t get_mac5() const // NOLINT(build/unsigned)
+        {
+            return mac5 ; // NOLINT(build/unsigned)
+        }
+
+        /** @brief Set the MAC5 identifier of the frame
+         */
+        void set_mac5(const uint16_t new_mac5) // NOLINT(build/unsigned)
+        {
+            mac5 = new_mac5;
+        }
+
+        /** @brief Get the flags field of the CRTBernData
+        */
+        uint16_t get_flags() const // NOLINT(build/unsigned)
+        {
+            return data.flags; // NOLINT(build/unsigned)
+        }
+
+        /** @brief Set the flags field of the CRTBernData
+         */
+        void set_flags(const uint16_t new_flags) // NOLINT(build/unsigned)
+        {
+            data.flags = new_flags;
+        }
+
+        /** @brief Get the lostcpu counter of the CRTBernData
+         */
+        uint16_t get_lostcpu() const // NOLINT(build/unsigned)
+        {
+            return data.lostcpu; // NOLINT(build/unsigned)
+        }
+
+        /** @brief Set the lostcpu counter of the CRTBernData
+         */
+        void set_lostcpu(const uint16_t new_lostcpu) // NOLINT(build/unsigned)
+        {
+            data.lostcpu = new_lostcpu;
+        }
+
+        /** @brief Get the lostfpga counter of the CRTBernData
+        */
+        uint16_t get_lostfpga() const // NOLINT(build/unsigned)
+        {
+            return data.lostfpga; // NOLINT(build/unsigned)
+        }
+
+        /** @brief Set the lostfpga counter of the CRTBernData
+        */
+        void set_lostfpga(const uint16_t new_lostfpga) // NOLINT(build/unsigned)
+        {
+            data.lostfpga = new_lostfpga;
+        }
+
+        /** @brief Get the ts0 timestamp of the CRTBernData
+         */
+        uint32_t get_ts0() const
+        {
+            return data.ts0;
+        }
+
+        /** @brief Set the ts0 timestamp of the CRTBernData
+         */
+        void set_ts0(const uint32_t new_ts0)
+        {
+            data.ts0 = new_ts0;
+        }
+
+        /** @brief Get the ts1 timestamp of the CRTBernData
+        */
+        uint32_t get_ts1() const
+        {
+            return data.ts1;
+        }
+
+        /** @brief Set the ts1 timestamp of the CRTBernData
+        */
+        void set_ts1(const uint32_t new_ts1)
+        {
+            data.ts1 = new_ts1;
+        }
+
+
+        /** @brief Get the coinc counter of the CRTBernData
+        */
+        uint32_t get_coinc() const
+        {
+            return data.coinc;
+        }
+
+        /** @brief Set the coinc counter of the CRTBernData
+        */
+        void set_coinc(const uint32_t new_coinc)
+        {
+            data.coinc = new_coinc;
+        }
+
+
+    }; //CRTBernFrame
+
+} // namespace dunedaq::fddetdataformats
+
+
+#endif //FDDETDATAFORMATS_INCLUDE_FDDETDATAFORMATS_CRTBERNFRAME_HPP_

--- a/include/fddetdataformats/CRTGrenobleFrame.hpp
+++ b/include/fddetdataformats/CRTGrenobleFrame.hpp
@@ -1,0 +1,129 @@
+/**
+ * @file CRTGrenobleFrame.hpp
+ *
+ * Contains declaration of CRTGrenobleFrame, a class for accessing/holding raw CRT data from the 'Grenoble' panels ProtoDUNE-II VD
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+#ifndef FDDETDATAFORMATS_INCLUDE_FDDETDATAFORMATS_CRTGRENOBLEFRAME_HPP_
+#define FDDETDATAFORMATS_INCLUDE_FDDETDATAFORMATS_CRTGRENOBLEFRAME_HPP_
+
+#include "detdataformats/DAQEthHeader.hpp"
+
+#include <algorithm> // For std::min
+#include <cassert>   // For assert()
+#include <cstdint>   // For uint32_t etc
+#include <cstdio>
+#include <cstdlib>
+#include <stdexcept> // For std::out_of_range
+
+namespace dunedaq::fddetdataformats {
+
+/**
+ *  @brief Class for accessing/holding raw CRT data from the 'Grenoble' panels ProtoDUNE-II VD
+ *
+ */
+    class CRTGrenobleFrame
+    {
+    public:
+        // ===============================================================
+        // Preliminaries
+        // ===============================================================
+
+        // The definition of the format is in terms of 64-bit words
+        typedef uint64_t word_t; // NOLINT
+
+        static constexpr int      s_num_channels = 32;
+        static constexpr uint64_t s_DTS_ticks_per_second = 62'500'000;
+        static constexpr uint64_t s_ns_per_DTS_tick = 16;
+
+        static constexpr int s_bits_per_adc = 16;
+        static constexpr int s_bits_per_word = 8 * sizeof(word_t);
+        static constexpr int s_num_adcs = 64;
+
+        struct TGpsDateStruct{
+            unsigned int seconds        : 8;
+            unsigned int minutes        : 8;
+            unsigned int hours          : 8;
+            unsigned int year           : 8;
+
+            unsigned int day            : 16;
+            unsigned int new_date_cnt   : 12;
+            unsigned int irigb_dec_ver  : 3;
+            unsigned int irigb_valid    : 1;
+        };
+
+        struct STChannel{
+            int qTot=0;  ///< Total charge.
+            unsigned short n_zc=0; ///< CFD time.
+            float cfd=0.;            ///< CFD value
+            unsigned short flag=0;  ///< Flag containing trigger, trigger sum and overflow information.
+        };
+
+        struct STEvent{
+            unsigned int   eventID=0;           ///< Event ID.
+            unsigned int   dateInSec=0;         ///< Event date in seconds.
+            unsigned int   timestamp=0;         ///< Timestamp (4 ns) -> used to compute dt between events.
+            TGpsDateStruct gpsDate;                 ///< TGPS date
+            unsigned int   pps_interval=0;       ///< IRIG-B subdivision in a second, expressed in 100 ns clock ticks.
+            unsigned int   FIFO_AF_duration=0;  ///< FIFO AF duration (4 ns) -> integration of Almost full fifo since last accepted trigger
+
+            struct STChannel channels[32];
+        };
+
+        // ===============================================================
+        // Data members
+        // ===============================================================
+        detdataformats::DAQEthHeader daq_header;
+        STEvent event;
+
+        // ===============================================================
+        // Accessors
+        // ===============================================================
+
+        /**
+         * @brief Get the adc value for channel i_ch
+         */
+        int get_adc(int i_ch) const // NOLINT(build/unsigned)
+        {
+            if (i_ch < 0 || i_ch >= s_num_channels)
+                throw std::out_of_range("ADC channel index out of range");
+
+            return event.channels[i_ch].qTot;
+        }
+
+        /**
+         * @brief Set the adc value for channel i_ch to @p val
+         */
+        void set_adc(int i_ch, int val) // NOLINT(build/unsigned)
+        {
+            if (i_ch < 0 || i_ch >= s_num_channels)
+                throw std::out_of_range("ADC channel index out of range");
+
+            event.channels[i_ch].qTot=val;
+        }
+
+        /** @brief Get the starting 64-bit timestamp of the frame
+         */
+        uint64_t get_timestamp() const // NOLINT(build/unsigned)
+        {
+            return daq_header.get_timestamp() ; // NOLINT(build/unsigned)
+        }
+
+        /** @brief Set the starting 64-bit timestamp of the frame
+         */
+        void set_timestamp(const uint64_t new_timestamp) // NOLINT(build/unsigned)
+        {
+            daq_header.timestamp = new_timestamp;
+        }
+
+
+
+    }; //CRTGrenobleFrame
+
+} // namespace dunedaq::fddetdataformats
+
+
+#endif //FDDETDATAFORMATS_INCLUDE_FDDETDATAFORMATS_CRTGRENOBLEFRAME_HPP_


### PR DESCRIPTION

[crt_det_formats_pr_descr_1.pdf](https://github.com/user-attachments/files/19103807/crt_det_formats_pr_descr_1.pdf)
Associated PRs:
- https://github.com/DUNE-DAQ/detdataformats/pull/92
- https://github.com/DUNE-DAQ/daqdataformats/pull/65
- https://github.com/DUNE-DAQ/fdreadoutlibs/pull/246

This is part of addressing https://github.com/DUNE-DAQ/ehn1-operations-issues/issues/46 (second bullet point).

Description in the attached slides. To pull down / test:

```
export MY_DEV_AREA=dev_NP02_CRTData

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest_v5
dbt-create -b nightly NFD_DEV_250305_A9 $MY_DEV_AREA

cd $MY_DEV_AREA/sourcecode
git clone https://github.com/DUNE-DAQ/detdataformats.git -b wketchum_NP02_CRTData
git clone https://github.com/DUNE-DAQ/daqdataformats.git -b wketchum_NP02_CRTData
git clone https://github.com/DUNE-DAQ/fddetdataformats.git -b wketchum_NP02_CRTData
git clone https://github.com/DUNE-DAQ/fdreadoutlibs.git -b wketchum_NP02_CRTData

cd ../
source env.sh
dbt-build
dbt-unittest-summary.sh
```

Should see everything build, and all unit tests pass.
