### PR TITLE
Made a few minor changes in CRTBernFrame.hpp and CRTGrenobleFrame.hpp…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(fddetdataformats VERSION 2.3.0)
+project(fddetdataformats VERSION 2.4.0)
 
 find_package(daq-cmake REQUIRED)
 

--- a/include/fddetdataformats/CRTBernFrame.hpp
+++ b/include/fddetdataformats/CRTBernFrame.hpp
@@ -39,10 +39,6 @@ namespace dunedaq::fddetdataformats {
         static constexpr uint64_t s_DTS_ticks_per_second = 62'500'000;
         static constexpr uint64_t s_ns_per_DTS_tick = 16;
 
-        static constexpr int s_bits_per_adc = 16;
-        static constexpr int s_bits_per_word = 8 * sizeof(word_t);
-        static constexpr int s_num_adcs = 64;
-
         struct CRTBernData
         {
             uint16_t flags     = 0;
@@ -50,7 +46,7 @@ namespace dunedaq::fddetdataformats {
             uint16_t lostfpga  = 0;
             uint32_t ts0       = 0;
             uint32_t ts1       = 0;
-            uint16_t adc[32]   = {0};
+            uint16_t adc[s_num_channels] = {0};
             uint32_t coinc      = 0;
         };
 

--- a/include/fddetdataformats/CRTGrenobleFrame.hpp
+++ b/include/fddetdataformats/CRTGrenobleFrame.hpp
@@ -39,10 +39,6 @@ namespace dunedaq::fddetdataformats {
         static constexpr uint64_t s_DTS_ticks_per_second = 62'500'000;
         static constexpr uint64_t s_ns_per_DTS_tick = 16;
 
-        static constexpr int s_bits_per_adc = 16;
-        static constexpr int s_bits_per_word = 8 * sizeof(word_t);
-        static constexpr int s_num_adcs = 64;
-
         struct TGpsDateStruct{
             unsigned int seconds        : 8;
             unsigned int minutes        : 8;
@@ -70,7 +66,7 @@ namespace dunedaq::fddetdataformats {
             unsigned int   pps_interval=0;       ///< IRIG-B subdivision in a second, expressed in 100 ns clock ticks.
             unsigned int   FIFO_AF_duration=0;  ///< FIFO AF duration (4 ns) -> integration of Almost full fifo since last accepted trigger
 
-            struct STChannel channels[32];
+            struct STChannel channels[s_num_channels];
         };
 
         // ===============================================================


### PR DESCRIPTION
… - removed unused constants and used the existing constant for the number of channels in the corresponding array declaration.

Some background:

When trying to calculate the size of CRT frames, I found the presence of unused constants confusing.  So, I am proposing to remove them.

And, the declarations of channel-based arrays using the bare number "32" instead of using the constant that specifies the number of channels seems like a bug waiting to happen (when someone changes one of values and doesn't realize that the other value needs to be changed).