### PR TITLE
Johnfreeman/prep release merged

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(fddetdataformats VERSION 2.5.0)
+project(fddetdataformats VERSION 2.6.0)
 
 find_package(daq-cmake REQUIRED)
 

--- a/include/fddetdataformats/DAPHNEEthStreamFrame.hpp
+++ b/include/fddetdataformats/DAPHNEEthStreamFrame.hpp
@@ -1,0 +1,195 @@
+/**
+ * @file DAPHNEEthStreamFrame.hpp
+ *
+ * Contains declaration of DAPHNEEthStreamFrame, a class for accessing raw DAPHNE eth stream frames, as used in ProtoDUNE-SP-II
+ * 
+ * The canonical definition of the DAPHNE format is given in EDMS document 2088726: 
+ * https://edms.cern.ch/document/2088726
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef FDDETDATAFORMATS_INCLUDE_FDDETDATAFORMATS_DAPHNEETHSTREAMFRAME_HPP_
+#define FDDETDATAFORMATS_INCLUDE_FDDETDATAFORMATS_DAPHNEETHSTREAMFRAME_HPP_
+
+#include "detdataformats/DAQEthHeader.hpp"
+
+#include <algorithm> // For std::min
+#include <cassert>   // For assert()
+#include <cstdint>   // For uint32_t etc
+#include <cstdio>
+#include <cstdlib>
+#include <stdexcept> // For std::out_of_range
+
+namespace dunedaq::fddetdataformats {
+
+/**
+ *  @brief Class for accessing raw DAPHNE eth stream frames, as used in ProtoDUNE-II
+ *
+ *  The canonical definition of the DAPHNE format is given in EDMS document 2088713:
+ *  https://edms.cern.ch/document/2088726
+ */
+class DAPHNEEthStreamFrame
+{
+public:
+  // ===============================================================
+  // Preliminaries
+  // ===============================================================
+
+  // The definition of the format is in terms of 64-bit words
+  typedef uint64_t word_t; // NOLINT
+
+  // Dataframe format version
+  static constexpr uint8_t version = 1;
+
+  static constexpr int s_bits_per_adc = 14;
+  static constexpr int s_bits_per_word = 8 * sizeof(word_t);
+  static constexpr int s_adcs_per_channel = 280;
+  static constexpr int s_num_channels = 4;
+  static constexpr int s_num_adc_words = s_num_channels * s_adcs_per_channel * s_bits_per_adc / s_bits_per_word;
+
+  struct ChannelWord
+  {
+    word_t tbd     : 52;
+    word_t version : 4;
+    word_t channel : 8;
+  };
+
+  struct Header
+  {    
+    ChannelWord channel_words[s_num_channels];
+  };
+
+  // ===============================================================
+  // Data members
+  // ===============================================================
+  detdataformats::DAQEthHeader daq_header;
+  Header header;
+  word_t adc_words[s_num_adc_words]; // NOLINT
+
+// ===============================================================
+// Accessors
+// ===============================================================
+
+/**
+ * @brief Get the @p i ADC value of @p chn in the frame
+ */
+uint16_t get_adc(uint i, uint chn) const // NOLINT
+{
+
+    if (i >= s_adcs_per_channel)
+      throw std::out_of_range("ADC index out of range");
+
+    if (chn >= s_num_channels)
+      throw std::out_of_range("Channel index out of range");
+
+    // find absolute index in frame
+    uint j = i*s_num_channels+chn;
+    // The index of the first (and sometimes only) word containing the required ADC value
+    uint word_index = s_bits_per_adc * j / s_bits_per_word;
+    assert(word_index < s_num_adc_words);
+    // Where in the word the lowest bit of our ADC value is located
+    int first_bit_position = (s_bits_per_adc * j) % s_bits_per_word;
+    // How many bits of our desired ADC are located in the `word_index`th word
+    int bits_from_first_word = std::min(s_bits_per_adc, s_bits_per_word - first_bit_position);
+    uint16_t adc = adc_words[word_index] >> first_bit_position; // NOLINT(build/unsigned)
+
+    if (bits_from_first_word < s_bits_per_adc) {
+      assert(word_index + 1 < s_num_adc_words);
+      adc |= adc_words[word_index + 1] << bits_from_first_word;
+    }
+    // Mask out all but the lowest 14 bits;
+    return adc & 0x3FFFu;
+}
+
+/**
+ * @brief Set the @p i ADC value of @p chn in the frame to @p val
+ */
+void set_adc(uint chn, uint i, uint16_t val) // NOLINT
+{
+    if (chn >= s_num_channels)
+      throw std::out_of_range("Channel index out of range");
+
+    if (i >= s_adcs_per_channel)
+      throw std::out_of_range("ADC index out of range");
+
+    if (val >= (1 << s_bits_per_adc))
+      throw std::out_of_range("ADC value out of range");
+
+
+    // find absolute index in frame
+    uint j = i*s_num_channels+chn;
+    // The index of the first (and sometimes only) word containing the required ADC value
+    int word_index = s_bits_per_adc * j / s_bits_per_word;
+    assert(word_index < s_num_adc_words);
+    // Where in the word the lowest bit of our ADC value is located
+    int first_bit_position = (s_bits_per_adc * j) % s_bits_per_word;
+    // How many bits of our desired ADC are located in the `word_index`th word
+    int bits_in_first_word = std::min(s_bits_per_adc, s_bits_per_word - first_bit_position);
+    uint32_t mask = (1 << (first_bit_position)) - 1;
+    adc_words[word_index] = ((val << first_bit_position) & ~mask) | (adc_words[word_index] & mask);
+    // If we didn't put the full 14 bits in this word, we need to put the rest in the next word
+    if (bits_in_first_word < s_bits_per_adc) {
+      assert(word_index + 1 < s_num_adc_words);
+      mask = (1 << (s_bits_per_adc - bits_in_first_word)) - 1;
+      adc_words[word_index + 1] = ((val >> bits_in_first_word) & mask) | (adc_words[word_index + 1] & ~mask);
+    }
+
+  }
+  /** @brief Get the starting 64-bit timestamp of the frame
+   */
+  uint64_t get_timestamp() const // NOLINT(build/unsigned)
+  {
+    return daq_header.get_timestamp() ; // NOLINT(build/unsigned)
+  }
+
+  /** @brief Set the starting 64-bit timestamp of the frame
+   */
+  void set_timestamp(const uint64_t new_timestamp) // NOLINT(build/unsigned)
+  {
+    daq_header.timestamp = new_timestamp;
+  }
+
+  /** @brief Get the channel identifier of the frame
+   */
+  uint8_t get_channel(uint ch) const // NOLINT(build/unsigned)
+  {
+    if (ch >= s_num_channels)
+      throw std::out_of_range("Channel index out of range");
+
+    return header.channel_words[ch].channel ; // NOLINT(build/unsigned)
+  }
+
+  /** @brief Set the channel identifier of the frame
+   */
+  void set_channel(uint channel_index, const uint8_t new_channel_val) // NOLINT(build/unsigned)
+  {
+    if (channel_index >= s_num_channels)
+      throw std::out_of_range("Channel index out of range");
+
+    header.channel_words[channel_index].channel = new_channel_val;
+  }
+  
+  /** @brief Get the channel 0 from the DAPHNE Stream frame header                                                                                                           
+   */
+  uint8_t get_channel0() const { return header.channel_words[0].channel; } // NOLINT(build/unsigned)                                                                                        
+
+  /** @brief Get the channel 1 from the DAPHNE Stream frame header                                                                                                           
+   */
+  uint8_t get_channel1() const { return header.channel_words[1].channel; } // NOLINT(build/unsigned)                                                                                        
+
+  /** @brief Get the channel 2 from the DAPHNE Stream frame header                                                                                                           
+   */
+  uint8_t get_channel2() const { return header.channel_words[2].channel; } // NOLINT(build/unsigned)                                                                                        
+
+  /** @brief Get the channel 3 from the DAPHNE Stream frame header                                                                                                           
+   */
+  uint8_t get_channel3() const { return header.channel_words[3].channel; } // NOLINT(build/unsigned)  
+
+};
+
+} // namespace dunedaq::fddetdataformats
+
+#endif // FDDETDATAFORMATS_INCLUDE_FDDETDATAFORMATS_DAPHNEETHSTREAMFRAME_HPP_

--- a/pybindsrc/daphneeth.cpp
+++ b/pybindsrc/daphneeth.cpp
@@ -49,10 +49,6 @@ register_daphneeth(py::module& m)
       [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.w6;},
       [](DAPHNEEthFrame::Header& self, uint32_t w6) {self.w6 = w6;}
       )
-
-
-      
-
     .def_property("channel",
       [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.channel;},
       [](DAPHNEEthFrame::Header& self, uint32_t channel) {self.channel = channel;}
@@ -61,62 +57,18 @@ register_daphneeth(py::module& m)
       [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.version;},
       [](DAPHNEEthFrame::Header& self, uint32_t version) {self.version = version;}
       )
-    // // .def_property("reserved",
-    //   // [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.reserved;},
-    //   // [](DAPHNEEthFrame::Header& self, uint32_t reserved) {self.reserved = reserved;}
-    //   // )
-    // .def_property("cd",
-    //   [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.cd;},
-    //   [](DAPHNEEthFrame::Header& self, uint32_t cd) {self.version = cd;}
-    //   )
-    // .def_property("context",
-    //   [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.context;},
-    //   [](DAPHNEEthFrame::Header& self, uint32_t context) {self.version = context;}
-    //   )
-    // .def_property("ready",
-    //   [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.ready;},
-    //   [](DAPHNEEthFrame::Header& self, uint32_t ready) {self.ready = ready;}
-    //   )
-    // .def_property("calibration",
-    //   [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.calibration;},
-    //   [](DAPHNEEthFrame::Header& self, uint32_t calibration) {self.calibration = calibration;}
-    //   )
-    // .def_property("pulser",
-    //   [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.pulser;},
-    //   [](DAPHNEEthFrame::Header& self, uint32_t pulser) {self.pulser = pulser;}
-    //   )
-    // .def_property("femb_sync",
-    //   [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.femb_sync;},
-    //   [](DAPHNEEthFrame::Header& self, uint32_t femb_sync) {self.femb_sync = femb_sync;}
-    //   )
-    // .def_property("wib_sync",
-    //   [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.wib_sync;},
-    //   [](DAPHNEEthFrame::Header& self, uint32_t wib_sync) {self.wib_sync = wib_sync;}
-    //   )
-    // .def_property("lol",
-    //   [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.lol;},
-    //   [](DAPHNEEthFrame::Header& self, uint32_t lol) {self.lol = lol;}
-    //   )
-    // .def_property("link_valid",
-    //   [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.link_valid;},
-    //   [](DAPHNEEthFrame::Header& self, uint32_t link_valid) {self.link_valid = link_valid;}
-    //   )
-    // .def_property("crc_err",
-    //   [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.crc_err;},
-    //   [](DAPHNEEthFrame::Header& self, uint32_t crc_err) {self.crc_err = crc_err;}
-    //   )
-    // .def_property("colddata_timestamp_1",
-    //   [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.colddata_timestamp_1;},
-    //   [](DAPHNEEthFrame::Header& self, uint32_t colddata_timestamp_1) {self.lol = colddata_timestamp_1;}
-    //   )
-    // .def_property("colddata_timestamp_0",
-    //   [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.colddata_timestamp_0;},
-    //   [](DAPHNEEthFrame::Header& self, uint32_t colddata_timestamp_0) {self.colddata_timestamp_0 = colddata_timestamp_0;}
-    //   )
-    // .def_property("extra_data",
-    //   [](DAPHNEEthFrame::Header& self) -> uint64_t {return self.extra_data;},
-    //   [](DAPHNEEthFrame::Header& self, uint64_t extra_data) {self.extra_data = extra_data;}
-    //   )
+    .def_property("trigger_sample_value",
+      [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.trig_sample;},
+      [](DAPHNEEthFrame::Header& self, uint32_t trig_sample) {self.trig_sample = trig_sample;}
+      )
+    .def_property("threshold",
+      [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.threshold;},
+      [](DAPHNEEthFrame::Header& self, uint32_t threshold) {self.threshold = threshold;}
+      )
+    .def_property("baseline",
+      [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.baseline;},
+      [](DAPHNEEthFrame::Header& self, uint32_t baseline) {self.baseline = baseline;}
+      )
     ;
 
   py::class_<DAPHNEEthFrame>(m, "DAPHNEEthFrame", py::buffer_protocol())
@@ -132,6 +84,7 @@ register_daphneeth(py::module& m)
     }))
     .def("get_daqheader", [](DAPHNEEthFrame& self) -> const detdataformats::DAQEthHeader& {return self.daq_header;}, py::return_value_policy::reference_internal)
     .def("get_daphneheader", [](DAPHNEEthFrame& self) -> const DAPHNEEthFrame::Header& {return self.header;}, py::return_value_policy::reference_internal)
+    .def("get_header", [](DAPHNEEthFrame& self) -> const DAPHNEEthFrame::Header& {return self.header;}, py::return_value_policy::reference_internal)
     .def("get_adc", &DAPHNEEthFrame::get_adc)
     .def("set_adc", &DAPHNEEthFrame::set_adc)
     .def("get_timestamp", &DAPHNEEthFrame::get_timestamp)

--- a/pybindsrc/daphneethstream.cpp
+++ b/pybindsrc/daphneethstream.cpp
@@ -1,0 +1,86 @@
+/**
+ * @file daphneethstream.cpp Python bindings for the DAPHNEEthStreamFrame format
+ *
+ * This is part of the DUNE DAQ Software Suite, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "fddetdataformats/DAPHNEEthStreamFrame.hpp"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
+namespace dunedaq::fddetdataformats::python {
+
+void
+register_daphneethstream(py::module& m)
+{
+
+
+  py::class_<DAPHNEEthStreamFrame::ChannelWord>(m, "DAPHNEEthStreamChannelWord")
+    .def_property("tbd", 
+      [](DAPHNEEthStreamFrame::ChannelWord& self) -> uint64_t {return self.tbd;},
+      [](DAPHNEEthStreamFrame::ChannelWord& self, uint64_t tbd) {self.tbd = tbd;}
+    )
+    .def_property("version", 
+      [](DAPHNEEthStreamFrame::ChannelWord& self) -> uint64_t {return self.version;},
+      [](DAPHNEEthStreamFrame::ChannelWord& self, uint64_t version) {self.version = version;}
+    )
+    .def_property("channel", 
+      [](DAPHNEEthStreamFrame::ChannelWord& self) -> uint64_t {return self.channel;},
+      [](DAPHNEEthStreamFrame::ChannelWord& self, uint64_t channel) {self.channel = channel;}
+    )
+    ;
+
+  py::class_<DAPHNEEthStreamFrame::Header>(m, "DAPHNEEthStreamHeader")
+    .def_property("channel_words",
+      [](DAPHNEEthStreamFrame::Header& self) -> py::list {
+        py::list result;
+        for (int i = 0; i < 4; i++) {
+          result.append(self.channel_words[i]);
+        }
+        return result;
+      },
+      [](DAPHNEEthStreamFrame::Header& self, py::list channel_words) {
+        for (int i = 0; i < 4 && i < len(channel_words); i++) {
+          self.channel_words[i] = channel_words[i].cast<DAPHNEEthStreamFrame::ChannelWord>();
+        }
+      }
+    )
+    ;
+
+  py::class_<DAPHNEEthStreamFrame>(m, "DAPHNEEthStreamFrame", py::buffer_protocol())
+    .def(py::init())
+    .def(py::init([](py::capsule capsule) {
+        auto wfp = *static_cast<DAPHNEEthStreamFrame*>(capsule.get_pointer());
+        return wfp;
+    } ))
+    .def(py::init([](py::bytes bytes){
+        py::buffer_info info(py::buffer(bytes).request());
+        auto wfp = *static_cast<DAPHNEEthStreamFrame*>(info.ptr);
+        return wfp;
+    }))
+    .def("get_daqheader", [](DAPHNEEthStreamFrame& self) -> const detdataformats::DAQEthHeader& {return self.daq_header;}, py::return_value_policy::reference_internal)
+    .def("get_daphneheader", [](DAPHNEEthStreamFrame& self) -> const DAPHNEEthStreamFrame::Header& {return self.header;}, py::return_value_policy::reference_internal)
+    .def("get_adc", &DAPHNEEthStreamFrame::get_adc)
+    .def("set_adc", &DAPHNEEthStreamFrame::set_adc)
+    .def("get_timestamp", &DAPHNEEthStreamFrame::get_timestamp)
+    .def("set_timestamp", &DAPHNEEthStreamFrame::set_timestamp)
+    .def("get_channel", &DAPHNEEthStreamFrame::get_channel)
+    .def("set_channel", &DAPHNEEthStreamFrame::set_channel)
+    .def("get_channel0", &DAPHNEEthStreamFrame::get_channel0)
+    .def("get_channel1", &DAPHNEEthStreamFrame::get_channel1)
+    .def("get_channel2", &DAPHNEEthStreamFrame::get_channel2)
+    .def("get_channel3", &DAPHNEEthStreamFrame::get_channel3)
+    .def_static("sizeof", [](){ return sizeof(DAPHNEEthStreamFrame); })
+    .def("get_bytes",
+         [](DAPHNEEthStreamFrame* fr) -> py::bytes {
+           return py::bytes(reinterpret_cast<char*>(fr), sizeof(DAPHNEEthStreamFrame));
+        })
+  ;
+}
+
+} // namespace dunedaq::fddetdataformats::python

--- a/pybindsrc/module.cpp
+++ b/pybindsrc/module.cpp
@@ -25,6 +25,7 @@ PYBIND11_MODULE(_daq_fddetdataformats_py, m)
   register_wibeth(m);
   register_daphne(m);
   register_daphneeth(m);
+  register_daphneethstream(m);
   register_tde(m);
   register_tdeeth(m);
 }

--- a/pybindsrc/registrators.hpp
+++ b/pybindsrc/registrators.hpp
@@ -21,6 +21,7 @@ namespace dunedaq::fddetdataformats::python {
   void register_wib(pybind11::module&);
   void register_daphne(pybind11::module&);
   void register_daphneeth(pybind11::module&);
+  void register_daphneethstream(pybind11::module&);
   void register_tde(pybind11::module&);
   void register_tdeeth(pybind11::module&);
 }


### PR DESCRIPTION
With `fddaq-v5.5.0` now cut, this source branch consists of a fork of the `develop` branch with `prep-release/fddaq-v5.5.0` merged in (i.e., this will be a fast-forward merge which brings the `fddaq-v5.5.0` code into `develop`). Over the weekend a test nightly was created, `MRGFD_DEV_251213_A9`, in which all the `johnfreeman/prep_release_merged` branches were used, and if I `pip install -U . ` the `johnfreeman/prep_release_merged` branch of `drunc`, integration tests with it look fine. 

# Description

_If full decription and testing details are included on a parent issue, please link to that here._
See issue # for details

_Otherwise, please include a summary of the change and which issue is fixed (if any).
Include relevant motivation and context, including a target environment and dunedaq version if known.
Also list any dependencies that are required for this change._
Addresses issue # 

_Please also include instructions for how a reviewer can test your changes._


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

