### PR TITLE
fix WIBEth set_adc bug (Issue #47) and adjust unit_test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ daq_setup_environment()
 
 find_package(detdataformats REQUIRED)
 find_package(Boost COMPONENTS unit_test_framework REQUIRED)
-find_package(TRACE REQUIRED)
+find_package(logging REQUIRED)
 
 ##############################################################################
 
@@ -19,7 +19,7 @@ daq_add_python_bindings(*.cpp )
 
 ##############################################################################
 
-daq_add_unit_test(WIBEthFrame_test LINK_LIBRARIES TRACE::TRACE fddetdataformats) 
+daq_add_unit_test(WIBEthFrame_test LINK_LIBRARIES fddetdataformats logging) 
 daq_add_unit_test(WIB2Frame_test   LINK_LIBRARIES fddetdataformats)
 daq_add_unit_test(WIBFrame_test    LINK_LIBRARIES fddetdataformats)
 daq_add_unit_test(TDE16Frame_test  LINK_LIBRARIES fddetdataformats)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ daq_setup_environment()
 
 find_package(detdataformats REQUIRED)
 find_package(Boost COMPONENTS unit_test_framework REQUIRED)
+find_package(TRACE REQUIRED)
 
 ##############################################################################
 
@@ -18,7 +19,7 @@ daq_add_python_bindings(*.cpp )
 
 ##############################################################################
 
-daq_add_unit_test(WIBEthFrame_test LINK_LIBRARIES fddetdataformats) 
+daq_add_unit_test(WIBEthFrame_test LINK_LIBRARIES TRACE::TRACE fddetdataformats) 
 daq_add_unit_test(WIB2Frame_test   LINK_LIBRARIES fddetdataformats)
 daq_add_unit_test(WIBFrame_test    LINK_LIBRARIES fddetdataformats)
 daq_add_unit_test(TDE16Frame_test  LINK_LIBRARIES fddetdataformats)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ daq_add_python_bindings(*.cpp )
 
 ##############################################################################
 
-daq_add_unit_test(WIBEthFrame_test LINK_LIBRARIES fddetdataformats logging) 
+daq_add_unit_test(WIBEthFrame_test LINK_LIBRARIES fddetdataformats logging::logging) 
 daq_add_unit_test(WIB2Frame_test   LINK_LIBRARIES fddetdataformats)
 daq_add_unit_test(WIBFrame_test    LINK_LIBRARIES fddetdataformats)
 daq_add_unit_test(TDE16Frame_test  LINK_LIBRARIES fddetdataformats)

--- a/include/fddetdataformats/WIBEthFrame.hpp
+++ b/include/fddetdataformats/WIBEthFrame.hpp
@@ -133,13 +133,15 @@ public:
     int first_bit_position = (s_bits_per_adc * i) % s_bits_per_word;
     // How many bits of our desired ADC are located in the `word_index`th word
     int bits_in_first_word = std::min(s_bits_per_adc, s_bits_per_word - first_bit_position);
-    uint64_t mask = (static_cast<uint64_t>(1) << first_bit_position) - 1;
-    adc_words[sample][word_index] = ((static_cast<uint64_t>(val) << first_bit_position) & ~mask) | (adc_words[sample][word_index] & mask);
+    // Create a mask that covers exactly the bits we want to modify (bits_in_first_word bits starting at first_bit_position)
+    uint64_t adc_mask = ((static_cast<uint64_t>(1) << bits_in_first_word) - 1) << first_bit_position;
+    adc_words[sample][word_index] = (adc_words[sample][word_index] & ~adc_mask) | ((static_cast<uint64_t>(val) << first_bit_position) & adc_mask);
     // If we didn't put the full 14 bits in this word, we need to put the rest in the next word
     if (bits_in_first_word < s_bits_per_adc) {
       assert(word_index + 1 < s_num_adc_words);
-      mask = (1 << (s_bits_per_adc - bits_in_first_word)) - 1;
-      adc_words[sample][word_index + 1] = ((val >> bits_in_first_word) & mask) | (adc_words[sample][word_index + 1] & ~mask);
+      int bits_in_second_word = s_bits_per_adc - bits_in_first_word;
+      uint64_t mask2 = (static_cast<uint64_t>(1) << bits_in_second_word) - 1;
+      adc_words[sample][word_index + 1] = (adc_words[sample][word_index + 1] & ~mask2) | ((val >> bits_in_first_word) & mask2);
     }
   }
 

--- a/unittest/WIBEthFrame_test.cxx
+++ b/unittest/WIBEthFrame_test.cxx
@@ -16,7 +16,7 @@
 #include <string>
 #include <vector>
 #include <random>
-#include <TRACE/trace.h>  // For TLOG_DEBUG
+#include <logging/Logging.hpp>  // For TLOG_DEBUG
 
 BOOST_AUTO_TEST_SUITE(WIBEthFrame_test)
 

--- a/unittest/WIBEthFrame_test.cxx
+++ b/unittest/WIBEthFrame_test.cxx
@@ -12,11 +12,11 @@
 #define BOOST_TEST_MODULE WIBEthFrame_test
 
 #include "boost/test/unit_test.hpp"
+#include "logging/Logging.hpp"  // For TLOG_DEBUG
 
 #include <string>
 #include <vector>
 #include <random>
-#include <logging/Logging.hpp>  // For TLOG_DEBUG
 
 BOOST_AUTO_TEST_SUITE(WIBEthFrame_test)
 

--- a/unittest/WIBEthFrame_test.cxx
+++ b/unittest/WIBEthFrame_test.cxx
@@ -16,6 +16,7 @@
 #include <string>
 #include <vector>
 #include <random>
+#include <TRACE/trace.h>  // For TLOG_DEBUG
 
 BOOST_AUTO_TEST_SUITE(WIBEthFrame_test)
 
@@ -44,10 +45,12 @@ BOOST_AUTO_TEST_CASE(WIBEthFrame_ADCDataMutators)
       wibethframe.set_adc(i, j, v[i][j]);
     }
   }
+  wibethframe.set_adc(0, 0, v[0][0]); // Set the first ADC again to check that we can overwrite existing values without affecting other values
 
   // Get ADCs and compare
   for(std::size_t i=0; i<v.size(); ++i) {
     for(std::size_t j=0; j<v[i].size(); ++j) {
+      TLOG_DEBUG(1) << "Comparing ADC value for channel " << i << ", sample " << j << ": " << wibethframe.get_adc(i, j) << " vs " << v[i][j];
       BOOST_REQUIRE_EQUAL(wibethframe.get_adc(i, j), v[i][j]);
     }
   }


### PR DESCRIPTION
# Description

See issue #47 for details


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [X] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

The PR includes a change to the unit test which, if applied before the patch to the header file, will trigger the bug, and
will passed after the patch is applied to the header.

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

