### PR TITLE
JCF: Issue #56: remove Python binding registration for no-longer-exis…

### DIFF
--- a/pybindsrc/module.cpp
+++ b/pybindsrc/module.cpp
@@ -18,13 +18,10 @@ PYBIND11_MODULE(_daq_fddetdataformats_py, m)
 
   m.doc() = "C++ implementation of the fddetdataformats modules";
 
-  register_wib(m);
-  register_wib2(m);
   register_wibeth(m);
   register_daphne(m);
   register_daphneeth(m);
   register_daphneethstream(m);
-  register_tde(m);
   register_tdeeth(m);
 }
 

--- a/pybindsrc/registrators.hpp
+++ b/pybindsrc/registrators.hpp
@@ -16,19 +16,13 @@
 namespace dunedaq::fddetdataformats::python {
 
 void
-register_wib2(pybind11::module&);
-void
 register_wibeth(pybind11::module&);
-void
-register_wib(pybind11::module&);
 void
 register_daphne(pybind11::module&);
 void
 register_daphneeth(pybind11::module&);
 void
 register_daphneethstream(pybind11::module&);
-void
-register_tde(pybind11::module&);
 void
 register_tdeeth(pybind11::module&);
 } // namespace dunedaq::fddetdataformats::python


### PR DESCRIPTION
…ting TDE16, WIB, and WIB2 frames; these were removed in the now-merged PR #54

# Description

See issue #56 for details

To test, see that `import fddetdataformats` works when this branch is used, and that it doesn't work when the head of `develop` is used. 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [X ] Unit tests pass (e.g. `dbt-build --unittest`)
- [X ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [X ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

