### PR TITLE
Wketchum/daphneeth updates from manuel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ daq_add_unit_test(WIB2Frame_test   LINK_LIBRARIES fddetdataformats)
 daq_add_unit_test(WIBFrame_test    LINK_LIBRARIES fddetdataformats)
 daq_add_unit_test(TDE16Frame_test  LINK_LIBRARIES fddetdataformats)
 daq_add_unit_test(DAPHNEFrame_test LINK_LIBRARIES fddetdataformats)
+daq_add_unit_test(DAPHNEEthFrame_test LINK_LIBRARIES fddetdataformats)
 
 ##############################################################################
 

--- a/include/fddetdataformats/DAPHNEEthFrame.hpp
+++ b/include/fddetdataformats/DAPHNEEthFrame.hpp
@@ -51,8 +51,6 @@ struct DAPHNEEthFrame
   static constexpr int s_num_adcs = 1024;
   static constexpr int s_num_adc_words = s_num_adcs * s_bits_per_adc / s_bits_per_word;
   static constexpr int s_max_peaks = 5;
-  static constexpr int s_peak_descriptor_words = 12;
-  static constexpr int s_packed_peak_descriptor_words = 6;
 
   /// @brief Single peak descriptor: two 32-bit words packed into one 64-bit word
   struct PeakDescriptor {

--- a/include/fddetdataformats/DAPHNEEthFrame.hpp
+++ b/include/fddetdataformats/DAPHNEEthFrame.hpp
@@ -1,9 +1,10 @@
 /**
  * @file DAPHNEEthFrame.hpp
  *
- * Contains declaration of DAPHNEEthFrame, a class for accessing raw WIB eth frames, as used in ProtoDUNE-SP-II
- * 
- * The canonical definition of the DAPHNE format is given in EDMS document 2088726: 
+ * Contains declaration of DAPHNEEthFrame, a class for accessing raw DAPHNE
+ * Ethernet frames.
+ *
+ * The canonical definition of the DAPHNE format is given in EDMS document 2088726:
  * https://edms.cern.ch/document/2088726
  *
  * This is part of the DUNE DAQ Application Framework, copyright 2020.
@@ -16,20 +17,22 @@
 
 #include "detdataformats/DAQEthHeader.hpp"
 
-#include <algorithm> // For std::min
-#include <cassert>   // For assert()
-#include <cstdint>   // For uint32_t etc
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
-#include <stdexcept> // For std::out_of_range
+#include <cstring>
+#include <stdexcept>
 
 namespace dunedaq::fddetdataformats {
 
 /**
- *  @brief Class for accessing raw WIB eth frames, as used in ProtoDUNE-II
+ *  @brief Class for accessing raw DAPHNE Ethernet frames.
  *
- *  The canonical definition of the WIB format is given in EDMS document 2088713:
- *  https://edms.cern.ch/document/2088726
+ *  The on-wire frame uses one 64-bit header word containing trigger metadata,
+ *  followed by six 64-bit words that carry twelve 32-bit peak descriptor words,
+ *  and finally 1024 packed ADC samples for a single channel.
  */
 class DAPHNEEthFrame
 {
@@ -38,8 +41,9 @@ public:
   // Preliminaries
   // ===============================================================
 
-  // The definition of the format is in terms of 64-bit words
+  // The top-level frame format is described in 64-bit words.
   typedef uint64_t word_t; // NOLINT
+  typedef uint32_t descriptor_word_t; // NOLINT
 
   // Dataframe format version
   static constexpr uint8_t version = 1;
@@ -48,25 +52,150 @@ public:
   static constexpr int s_bits_per_word = 8 * sizeof(word_t);
   static constexpr int s_num_adcs = 1024;
   static constexpr int s_num_adc_words = s_num_adcs * s_bits_per_adc / s_bits_per_word;
+  static constexpr int s_peak_descriptor_words = 12;
+  static constexpr int s_packed_peak_descriptor_words = 6;
+
+  struct PeakDescriptorData
+  {
+    // Word 1: peak 0 odd
+    descriptor_word_t num_subpeaks_0 : 4;
+    descriptor_word_t reserved_0 : 4;
+    descriptor_word_t adc_integral_0 : 23;
+    descriptor_word_t found_0 : 1;
+
+    // Word 2: peak 0 even
+    descriptor_word_t adc_max_0 : 14;
+    descriptor_word_t sample_max_0 : 9;
+    descriptor_word_t samples_over_baseline_0 : 9;
+
+    // Word 3: peak 1 odd
+    descriptor_word_t num_subpeaks_1 : 4;
+    descriptor_word_t reserved_1 : 4;
+    descriptor_word_t adc_integral_1 : 23;
+    descriptor_word_t found_1 : 1;
+
+    // Word 4: peak 1 even
+    descriptor_word_t adc_max_1 : 14;
+    descriptor_word_t sample_max_1 : 9;
+    descriptor_word_t samples_over_baseline_1 : 9;
+
+    // Word 5: peak 2 odd
+    descriptor_word_t num_subpeaks_2 : 4;
+    descriptor_word_t reserved_2 : 4;
+    descriptor_word_t adc_integral_2 : 23;
+    descriptor_word_t found_2 : 1;
+
+    // Word 6: peak 2 even
+    descriptor_word_t adc_max_2 : 14;
+    descriptor_word_t sample_max_2 : 9;
+    descriptor_word_t samples_over_baseline_2 : 9;
+
+    // Word 7: peak 3 odd
+    descriptor_word_t num_subpeaks_3 : 4;
+    descriptor_word_t reserved_3 : 4;
+    descriptor_word_t adc_integral_3 : 23;
+    descriptor_word_t found_3 : 1;
+
+    // Word 8: peak 3 even
+    descriptor_word_t adc_max_3 : 14;
+    descriptor_word_t sample_max_3 : 9;
+    descriptor_word_t samples_over_baseline_3 : 9;
+
+    // Word 9: peak 4 odd
+    descriptor_word_t num_subpeaks_4 : 4;
+    descriptor_word_t reserved_4 : 4;
+    descriptor_word_t adc_integral_4 : 23;
+    descriptor_word_t found_4 : 1;
+
+    // Word 10: peak 4 even
+    descriptor_word_t adc_max_4 : 14;
+    descriptor_word_t sample_max_4 : 9;
+    descriptor_word_t samples_over_baseline_4 : 9;
+
+    // Word 11: Time_Start fields for indices 0,1,2 and reserved bits [1:0]
+    descriptor_word_t samples_start_2 : 10;
+    descriptor_word_t samples_start_1 : 10;
+    descriptor_word_t samples_start_0 : 10;
+    descriptor_word_t reserved_5 : 2;
+
+    // Word 12: Time_Start fields for indices 3,4 and reserved bits [11:0]
+    descriptor_word_t reserved_6 : 12;
+    descriptor_word_t samples_start_4 : 10;
+    descriptor_word_t samples_start_3 : 10;
+
+    static constexpr uint8_t max_peaks = 5;
+
+    inline bool is_found(int idx) const;
+    inline void set_found(uint8_t val, int idx);
+
+    inline uint32_t get_adc_integral(int idx) const;
+    inline void set_adc_integral(uint32_t val, int idx);
+
+    inline uint8_t get_num_subpeaks(int idx) const;
+    inline void set_num_subpeaks(uint8_t val, int idx);
+
+    inline uint16_t get_samples_over_baseline(int idx) const;
+    inline void set_samples_over_baseline(uint16_t val, int idx);
+
+    inline uint16_t get_sample_max(int idx) const;
+    inline void set_sample_max(uint16_t val, int idx);
+
+    inline uint16_t get_adc_max(int idx) const;
+    inline void set_adc_max(uint16_t val, int idx);
+
+    inline uint16_t get_sample_start(int idx) const;
+    inline void set_sample_start(uint16_t val, int idx);
+
+    inline const descriptor_word_t* as_words() const
+    {
+      return reinterpret_cast<const descriptor_word_t*>(this);
+    }
+
+    inline descriptor_word_t* as_words()
+    {
+      return reinterpret_cast<descriptor_word_t*>(this);
+    }
+  };
 
   struct Header
-  {	  
-    // word_t w0;
+  {
     word_t trig_sample : 14;
-    word_t rsv_0       : 2;
-    word_t threshold   : 14;
-    word_t rsv_1       : 2;
-    word_t baseline    : 14;
-    word_t rsv_2       : 6;
-    word_t version     : 4;
-    word_t channel     : 8;
+    word_t rsv_0 : 2;
+    word_t threshold : 14;
+    word_t rsv_1 : 2;
+    word_t baseline : 14;
+    word_t rsv_2 : 6;
+    word_t version : 4;
+    word_t channel : 8;
 
-    word_t w1;
-    word_t w2;
-    word_t w3;
-    word_t w4;
-    word_t w5;
-    word_t w6;
+    PeakDescriptorData peaks_data;
+
+    descriptor_word_t get_baseline() const
+    {
+      return static_cast<descriptor_word_t>(baseline);
+    }
+
+    word_t get_packed_peak_word(int idx) const
+    {
+      if (idx < 0 || idx >= s_packed_peak_descriptor_words) {
+        throw std::out_of_range("Packed peak word index out of range (must be 0-5)");
+      }
+      word_t value = 0;
+      std::memcpy(&value,
+                  reinterpret_cast<const uint8_t*>(&peaks_data) + idx * sizeof(word_t),
+                  sizeof(value));
+      return value;
+    }
+
+    void set_packed_peak_word(word_t value, int idx)
+    {
+      if (idx < 0 || idx >= s_packed_peak_descriptor_words) {
+        throw std::out_of_range("Packed peak word index out of range (must be 0-5)");
+      }
+      std::memcpy(reinterpret_cast<uint8_t*>(&peaks_data) + idx * sizeof(word_t),
+                  &value,
+                  sizeof(value));
+    }
   };
 
   // ===============================================================
@@ -76,97 +205,274 @@ public:
   Header header;
   word_t adc_words[s_num_adc_words]; // NOLINT
 
-// ===============================================================
-// Accessors
-// ===============================================================
+  // ===============================================================
+  // Accessors
+  // ===============================================================
 
-/**
-  * @brief Get the ith ADC value in the frame
-  *
-  * The ADC words are 14 bits long, stored packed in the data structure. The order is:
-  *
-  * - 1024 adc values from one daphne channel
-  */
-uint16_t
-get_adc(int i) const // NOLINT
-{
-  if (i < 0 || i >= s_num_adcs)
-    throw std::out_of_range("ADC index out of range");
-
-  // The index of the first (and sometimes only) word containing the required ADC value
-  int word_index = s_bits_per_adc * i / s_bits_per_word;
-  assert(word_index < s_num_adc_words);
-  // Where in the word the lowest bit of our ADC value is located
-  int first_bit_position = (s_bits_per_adc * i) % s_bits_per_word;
-  // How many bits of our desired ADC are located in the `word_index`th word
-  int bits_from_first_word = std::min(s_bits_per_adc, s_bits_per_word - first_bit_position);
-  uint16_t adc = adc_words[word_index] >> first_bit_position; // NOLINT
-  // If we didn't get the full 14 bits from this word, we need the rest from the next word
-  if (bits_from_first_word < s_bits_per_adc) {
-    assert(word_index + 1 < s_num_adc_words);
-    adc |= adc_words[word_index + 1] << bits_from_first_word;
-  }
-  // Mask out all but the lowest 14 bits;
-  return adc & 0x3FFFu;
-}
-
-/**
-  * @brief Set the ith ADC value in the frame to @p val
-  */
-void
-set_adc(int i, uint16_t val) // NOLINT
-{
-  if (i < 0 || i >= s_num_adcs)
-    throw std::out_of_range("ADC index out of range");
-  if (val >= (1 << s_bits_per_adc))
-    throw std::out_of_range("ADC value out of range");
-
-  // The index of the first (and sometimes only) word containing the required ADC value
-  int word_index = s_bits_per_adc * i / s_bits_per_word;
-  assert(word_index < s_num_adc_words);
-  // Where in the word the lowest bit of our ADC value is located
-  int first_bit_position = (s_bits_per_adc * i) % s_bits_per_word;
-  // How many bits of our desired ADC are located in the `word_index`th word
-  int bits_in_first_word = std::min(s_bits_per_adc, s_bits_per_word - first_bit_position);
-  uint32_t mask = (1 << (first_bit_position)) - 1;
-  adc_words[word_index] = ((val << first_bit_position) & ~mask) | (adc_words[word_index] & mask);
-  // If we didn't put the full 14 bits in this word, we need to put the rest in the next word
-  if (bits_in_first_word < s_bits_per_adc) {
-    assert(word_index + 1 < s_num_adc_words);
-    mask = (1 << (s_bits_per_adc - bits_in_first_word)) - 1;
-    adc_words[word_index + 1] = ((val >> bits_in_first_word) & mask) | (adc_words[word_index + 1] & ~mask);
-  }
-}
-
-  /** @brief Get the starting 64-bit timestamp of the frame
+  /**
+   * @brief Get the ith ADC value in the frame
    */
+  uint16_t get_adc(int i) const // NOLINT
+  {
+    if (i < 0 || i >= s_num_adcs) {
+      throw std::out_of_range("ADC index out of range");
+    }
+
+    int word_index = s_bits_per_adc * i / s_bits_per_word;
+    assert(word_index < s_num_adc_words);
+    int first_bit_position = (s_bits_per_adc * i) % s_bits_per_word;
+    int bits_from_first_word = std::min(s_bits_per_adc, s_bits_per_word - first_bit_position);
+    uint16_t adc = adc_words[word_index] >> first_bit_position; // NOLINT
+    if (bits_from_first_word < s_bits_per_adc) {
+      assert(word_index + 1 < s_num_adc_words);
+      adc |= adc_words[word_index + 1] << bits_from_first_word;
+    }
+    return adc & 0x3FFFu;
+  }
+
+  /**
+   * @brief Set the ith ADC value in the frame to @p val
+   */
+  void set_adc(int i, uint16_t val) // NOLINT
+  {
+    if (i < 0 || i >= s_num_adcs) {
+      throw std::out_of_range("ADC index out of range");
+    }
+    if (val >= (1 << s_bits_per_adc)) {
+      throw std::out_of_range("ADC value out of range");
+    }
+
+    int word_index = s_bits_per_adc * i / s_bits_per_word;
+    assert(word_index < s_num_adc_words);
+    int first_bit_position = (s_bits_per_adc * i) % s_bits_per_word;
+    int bits_in_first_word = std::min(s_bits_per_adc, s_bits_per_word - first_bit_position);
+    word_t lower_mask = (static_cast<word_t>(1) << first_bit_position) - 1;
+    adc_words[word_index] =
+      ((static_cast<word_t>(val) << first_bit_position) & ~lower_mask) |
+      (adc_words[word_index] & lower_mask);
+    if (bits_in_first_word < s_bits_per_adc) {
+      assert(word_index + 1 < s_num_adc_words);
+      word_t upper_mask = (static_cast<word_t>(1) << (s_bits_per_adc - bits_in_first_word)) - 1;
+      adc_words[word_index + 1] =
+        ((static_cast<word_t>(val) >> bits_in_first_word) & upper_mask) |
+        (adc_words[word_index + 1] & ~upper_mask);
+    }
+  }
+
   uint64_t get_timestamp() const // NOLINT(build/unsigned)
   {
-    return daq_header.get_timestamp() ; // NOLINT(build/unsigned)
+    return daq_header.get_timestamp();
   }
 
-  /** @brief Set the starting 64-bit timestamp of the frame
-   */
   void set_timestamp(const uint64_t new_timestamp) // NOLINT(build/unsigned)
   {
     daq_header.timestamp = new_timestamp;
   }
 
-  /** @brief Get the channel identifier of the frame
-   */
   uint8_t get_channel() const // NOLINT(build/unsigned)
   {
-    return header.channel ; // NOLINT(build/unsigned)
+    return header.channel;
   }
 
-  /** @brief Set the channel identifier of the frame
-   */
   void set_channel(const uint8_t new_channel) // NOLINT(build/unsigned)
   {
     header.channel = new_channel;
   }
 
+  const PeakDescriptorData& get_peaks_data() const
+  {
+    return header.peaks_data;
+  }
+
+  PeakDescriptorData& get_peaks_data()
+  {
+    return header.peaks_data;
+  }
 };
+
+static_assert(sizeof(DAPHNEEthFrame::PeakDescriptorData) ==
+                DAPHNEEthFrame::s_peak_descriptor_words * sizeof(DAPHNEEthFrame::descriptor_word_t),
+              "Unexpected DAPHNEEthFrame::PeakDescriptorData size");
+static_assert(sizeof(DAPHNEEthFrame::Header) == 7 * sizeof(DAPHNEEthFrame::word_t),
+              "Unexpected DAPHNEEthFrame::Header size");
+
+inline bool
+DAPHNEEthFrame::PeakDescriptorData::is_found(int idx) const
+{
+  if (idx < 0 || idx > 4) {
+    throw std::out_of_range("Peak index out of range (must be 0-4)");
+  }
+  const descriptor_word_t* tw = as_words();
+  return static_cast<uint8_t>((tw[2 * idx] >> 31) & 0x1);
+}
+
+inline void
+DAPHNEEthFrame::PeakDescriptorData::set_found(uint8_t val, int idx)
+{
+  if (idx < 0 || idx > 4) {
+    throw std::out_of_range("Peak index out of range (must be 0-4)");
+  }
+  if (val > 1) {
+    throw std::out_of_range("Found value out of range (must be 0-1)");
+  }
+  descriptor_word_t* tw = as_words();
+  tw[2 * idx] = (tw[2 * idx] & ~(descriptor_word_t(1u) << 31)) | ((val & 0x1u) << 31);
+}
+
+inline uint32_t
+DAPHNEEthFrame::PeakDescriptorData::get_adc_integral(int idx) const
+{
+  if (idx < 0 || idx > 4) {
+    throw std::out_of_range("Peak index out of range (must be 0-4)");
+  }
+  const descriptor_word_t* tw = as_words();
+  return (tw[2 * idx] >> 8) & 0x7FFFFF;
+}
+
+inline void
+DAPHNEEthFrame::PeakDescriptorData::set_adc_integral(uint32_t val, int idx)
+{
+  if (idx < 0 || idx > 4) {
+    throw std::out_of_range("Peak index out of range (must be 0-4)");
+  }
+  if (val > 0x7FFFFF) {
+    throw std::out_of_range("ADC integral value out of range (must be 0-8388607)");
+  }
+  descriptor_word_t* tw = as_words();
+  tw[2 * idx] = (tw[2 * idx] & ~(descriptor_word_t(0x7FFFFFu) << 8)) | ((val & 0x7FFFFFu) << 8);
+}
+
+inline uint8_t
+DAPHNEEthFrame::PeakDescriptorData::get_num_subpeaks(int idx) const
+{
+  if (idx < 0 || idx > 4) {
+    throw std::out_of_range("Peak index out of range (must be 0-4)");
+  }
+  const descriptor_word_t* tw = as_words();
+  return static_cast<uint8_t>(tw[2 * idx] & 0xF);
+}
+
+inline void
+DAPHNEEthFrame::PeakDescriptorData::set_num_subpeaks(uint8_t val, int idx)
+{
+  if (idx < 0 || idx > 4) {
+    throw std::out_of_range("Peak index out of range (must be 0-4)");
+  }
+  if (val > 0xF) {
+    throw std::out_of_range("Num_SubPeaks value out of range (must be 0-15)");
+  }
+  descriptor_word_t* tw = as_words();
+  tw[2 * idx] = (tw[2 * idx] & ~descriptor_word_t(0xFu)) | (val & 0xFu);
+}
+
+inline uint16_t
+DAPHNEEthFrame::PeakDescriptorData::get_samples_over_baseline(int idx) const
+{
+  if (idx < 0 || idx > 4) {
+    throw std::out_of_range("Peak index out of range (must be 0-4)");
+  }
+  const descriptor_word_t* tw = as_words();
+  return static_cast<uint16_t>((tw[2 * idx + 1] >> 23) & 0x1FF);
+}
+
+inline void
+DAPHNEEthFrame::PeakDescriptorData::set_samples_over_baseline(uint16_t val, int idx)
+{
+  if (idx < 0 || idx > 4) {
+    throw std::out_of_range("Peak index out of range (must be 0-4)");
+  }
+  if (val > 0x1FF) {
+    throw std::out_of_range("Time_Over_Baseline value out of range (must be 0-511)");
+  }
+  descriptor_word_t* tw = as_words();
+  tw[2 * idx + 1] = (tw[2 * idx + 1] & ~(descriptor_word_t(0x1FFu) << 23)) | ((val & 0x1FFu) << 23);
+}
+
+inline uint16_t
+DAPHNEEthFrame::PeakDescriptorData::get_sample_max(int idx) const
+{
+  if (idx < 0 || idx > 4) {
+    throw std::out_of_range("Peak index out of range (must be 0-4)");
+  }
+  const descriptor_word_t* tw = as_words();
+  return static_cast<uint16_t>((tw[2 * idx + 1] >> 14) & 0x1FF);
+}
+
+inline void
+DAPHNEEthFrame::PeakDescriptorData::set_sample_max(uint16_t val, int idx)
+{
+  if (idx < 0 || idx > 4) {
+    throw std::out_of_range("Peak index out of range (must be 0-4)");
+  }
+  if (val > 0x1FF) {
+    throw std::out_of_range("Time_Peak value out of range (must be 0-511)");
+  }
+  descriptor_word_t* tw = as_words();
+  tw[2 * idx + 1] = (tw[2 * idx + 1] & ~(descriptor_word_t(0x1FFu) << 14)) | ((val & 0x1FFu) << 14);
+}
+
+inline uint16_t
+DAPHNEEthFrame::PeakDescriptorData::get_adc_max(int idx) const
+{
+  if (idx < 0 || idx > 4) {
+    throw std::out_of_range("Peak index out of range (must be 0-4)");
+  }
+  const descriptor_word_t* tw = as_words();
+  return static_cast<uint16_t>(tw[2 * idx + 1] & 0x3FFF);
+}
+
+inline void
+DAPHNEEthFrame::PeakDescriptorData::set_adc_max(uint16_t val, int idx)
+{
+  if (idx < 0 || idx > 4) {
+    throw std::out_of_range("Peak index out of range (must be 0-4)");
+  }
+  if (val > 0x3FFF) {
+    throw std::out_of_range("ADC Max value out of range (must be 0-16383)");
+  }
+  descriptor_word_t* tw = as_words();
+  tw[2 * idx + 1] = (tw[2 * idx + 1] & ~descriptor_word_t(0x3FFFu)) | (val & 0x3FFFu);
+}
+
+inline uint16_t
+DAPHNEEthFrame::PeakDescriptorData::get_sample_start(int idx) const
+{
+  if (idx < 0 || idx > 4) {
+    throw std::out_of_range("Time_Start index out of range (must be 0-4)");
+  }
+
+  const descriptor_word_t* tw = as_words();
+  if (idx < 3) {
+    int shift = 22 - 10 * idx;
+    return static_cast<uint16_t>((tw[10] >> shift) & 0x3FF);
+  }
+
+  int shift = 22 - 10 * (idx - 3);
+  return static_cast<uint16_t>((tw[11] >> shift) & 0x3FF);
+}
+
+inline void
+DAPHNEEthFrame::PeakDescriptorData::set_sample_start(uint16_t val, int idx)
+{
+  if (idx < 0 || idx > 4) {
+    throw std::out_of_range("Time_Start index out of range (must be 0-4)");
+  }
+  if (val > 0x3FF) {
+    throw std::out_of_range("Time_Start value out of range (must be 0-1023)");
+  }
+
+  descriptor_word_t* tw = as_words();
+  descriptor_word_t mask = 0x3FFu;
+
+  if (idx < 3) {
+    int shift = 22 - 10 * idx;
+    tw[10] = (tw[10] & ~(mask << shift)) | ((val & mask) << shift);
+    return;
+  }
+
+  int shift = 22 - 10 * (idx - 3);
+  tw[11] = (tw[11] & ~(mask << shift)) | ((val & mask) << shift);
+}
 
 } // namespace dunedaq::fddetdataformats
 

--- a/include/fddetdataformats/DAPHNEEthFrame.hpp
+++ b/include/fddetdataformats/DAPHNEEthFrame.hpp
@@ -74,7 +74,7 @@ struct DAPHNEEthFrame
 
     static constexpr size_t s_expected_bytes { (DAPHNEEthFrame::s_max_peaks + 1) * sizeof(word_t) };
 
-    PeakDescriptor peaks[DAPHNEEthFrame::s_max_peaks];
+    PeakDescriptor peaks[DAPHNEEthFrame::s_max_peaks]; //NOLINT
 
     // Time_Start fields span two 32-bit words packed into one 64-bit word.
     // Word 11 (bits [31:0]): samples_start for indices 2, 1, 0
@@ -90,51 +90,51 @@ struct DAPHNEEthFrame
 
     /// @brief Get the Num_SubPeaks value for peak @p ipdx
     inline uint8_t get_num_subpeaks(int ipdx) const
-    { check_range_npeaks_(ipdx); return peaks[ipdx].num_subpeaks; }
+    { check_range_npeaks_(ipdx); return peaks[ipdx].num_subpeaks; } //NOLINT
 
     /// @brief Set the Num_SubPeaks value for peak @p ipdx
     inline void set_num_subpeaks(uint8_t val, int ipdx)
-    { check_range_npeaks_(ipdx); peaks[ipdx].num_subpeaks = val; }
+    { check_range_npeaks_(ipdx); peaks[ipdx].num_subpeaks = val; } //NOLINT
 
     /// @brief Get the Found flag for peak @p ipdx
     inline bool is_found(int ipdx) const
-    { check_range_npeaks_(ipdx); return peaks[ipdx].found; }
+    { check_range_npeaks_(ipdx); return peaks[ipdx].found; } //NOLINT
 
     /// @brief Set the Found flag for peak @p ipdx
     inline void set_found(uint8_t val, int ipdx)
-    { check_range_npeaks_(ipdx); peaks[ipdx].found = val; }
+    { check_range_npeaks_(ipdx); peaks[ipdx].found = val; } //NOLINT
 
     /// @brief Get the ADC_Integral value for peak @p ipdx
     inline uint32_t get_adc_integral(int ipdx) const
-    { check_range_npeaks_(ipdx); return peaks[ipdx].adc_integral; }
+    { check_range_npeaks_(ipdx); return peaks[ipdx].adc_integral; } //NOLINT
 
     /// @brief Set the ADC_Integral value for peak @p ipdx
     inline void set_adc_integral(uint32_t val, int ipdx)
-    { check_range_npeaks_(ipdx); peaks[ipdx].adc_integral = val; }
+    { check_range_npeaks_(ipdx); peaks[ipdx].adc_integral = val; } //NOLINT
 
     /// @brief Get the ADC_Max value for peak @p ipdx
     inline uint16_t get_adc_max(int ipdx) const
-    { check_range_npeaks_(ipdx); return peaks[ipdx].adc_max; }
+    { check_range_npeaks_(ipdx); return peaks[ipdx].adc_max; } //NOLINT
 
     /// @brief Set the ADC_Max value for peak @p ipdx
     inline void set_adc_max(uint16_t val, int ipdx)
-    { check_range_npeaks_(ipdx); peaks[ipdx].adc_max = val; }
+    { check_range_npeaks_(ipdx); peaks[ipdx].adc_max = val; } //NOLINT
 
     /// @brief Get the Time_Peak value for peak @p ipdx
     inline uint16_t get_sample_max(int ipdx) const
-    { check_range_npeaks_(ipdx); return peaks[ipdx].sample_max; }
+    { check_range_npeaks_(ipdx); return peaks[ipdx].sample_max; } //NOLINT
 
     /// @brief Set the Time_Peak value for peak @p ipdx
     inline void set_sample_max(uint16_t val, int ipdx)
-    { check_range_npeaks_(ipdx); peaks[ipdx].sample_max = val; }
+    { check_range_npeaks_(ipdx); peaks[ipdx].sample_max = val; } //NOLINT
 
     /// @brief Get the Time_Over_Baseline value for peak @p ipdx
     inline uint16_t get_samples_over_baseline(int ipdx) const
-    { check_range_npeaks_(ipdx); return peaks[ipdx].samples_over_baseline; }
+    { check_range_npeaks_(ipdx); return peaks[ipdx].samples_over_baseline; } //NOLINT
 
     /// @brief Set the Time_Over_Baseline value for peak @p ipdx
     inline void set_samples_over_baseline(uint16_t val, int ipdx)
-    { check_range_npeaks_(ipdx); peaks[ipdx].samples_over_baseline = val; }
+    { check_range_npeaks_(ipdx); peaks[ipdx].samples_over_baseline = val; } //NOLINT
 
     /// @brief Get the Time_Start value for peak @p ipdx
     inline uint16_t get_sample_start(int ipdx) const;
@@ -250,7 +250,6 @@ DAPHNEEthFrame::PeakDescriptorData::set_sample_start(uint16_t val, int ipdx)
   else if(ipdx==4)
     samples_start_4=val & 0x3FFu;
   
-  return;
 }
 
 } // namespace dunedaq::fddetdataformats

--- a/pybindsrc/daphneeth.cpp
+++ b/pybindsrc/daphneeth.cpp
@@ -1,5 +1,5 @@
 /**
- * @file wibeth.cpp Python bindings for the DAPHNEEthFrame format
+ * @file daphneeth.cpp Python bindings for the DAPHNEEthFrame format
  *
  * This is part of the DUNE DAQ Software Suite, copyright 2020.
  * Licensing/copyright details are in the COPYING file that you should have
@@ -18,84 +18,227 @@ namespace dunedaq::fddetdataformats::python {
 void
 register_daphneeth(py::module& m)
 {
-
-
   py::class_<DAPHNEEthFrame::Header>(m, "DAPHNEEthHeader")
-    // .def_property("w0",
-    //   [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.w0;},
-    //   [](DAPHNEEthFrame::Header& self, uint32_t w0) {self.w0 = w0;}
-    //   )      
     .def_property("w1",
-      [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.w1;},
-      [](DAPHNEEthFrame::Header& self, uint32_t w1) {self.w1 = w1;}
+      [](DAPHNEEthFrame::Header& self) -> uint64_t { return self.get_packed_peak_word(0); },
+      [](DAPHNEEthFrame::Header& self, uint64_t w1) { self.set_packed_peak_word(w1, 0); }
       )
     .def_property("w2",
-      [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.w2;},
-      [](DAPHNEEthFrame::Header& self, uint32_t w2) {self.w2 = w2;}
+      [](DAPHNEEthFrame::Header& self) -> uint64_t { return self.get_packed_peak_word(1); },
+      [](DAPHNEEthFrame::Header& self, uint64_t w2) { self.set_packed_peak_word(w2, 1); }
       )
     .def_property("w3",
-      [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.w3;},
-      [](DAPHNEEthFrame::Header& self, uint32_t w3) {self.w3 = w3;}
+      [](DAPHNEEthFrame::Header& self) -> uint64_t { return self.get_packed_peak_word(2); },
+      [](DAPHNEEthFrame::Header& self, uint64_t w3) { self.set_packed_peak_word(w3, 2); }
       )
     .def_property("w4",
-      [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.w4;},
-      [](DAPHNEEthFrame::Header& self, uint32_t w4) {self.w4 = w4;}
+      [](DAPHNEEthFrame::Header& self) -> uint64_t { return self.get_packed_peak_word(3); },
+      [](DAPHNEEthFrame::Header& self, uint64_t w4) { self.set_packed_peak_word(w4, 3); }
       )
     .def_property("w5",
-      [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.w5;},
-      [](DAPHNEEthFrame::Header& self, uint32_t w5) {self.w5 = w5;}
+      [](DAPHNEEthFrame::Header& self) -> uint64_t { return self.get_packed_peak_word(4); },
+      [](DAPHNEEthFrame::Header& self, uint64_t w5) { self.set_packed_peak_word(w5, 4); }
       )
     .def_property("w6",
-      [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.w6;},
-      [](DAPHNEEthFrame::Header& self, uint32_t w6) {self.w6 = w6;}
+      [](DAPHNEEthFrame::Header& self) -> uint64_t { return self.get_packed_peak_word(5); },
+      [](DAPHNEEthFrame::Header& self, uint64_t w6) { self.set_packed_peak_word(w6, 5); }
       )
     .def_property("channel",
-      [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.channel;},
-      [](DAPHNEEthFrame::Header& self, uint32_t channel) {self.channel = channel;}
+      [](DAPHNEEthFrame::Header& self) -> uint8_t { return self.channel; },
+      [](DAPHNEEthFrame::Header& self, uint8_t channel) { self.channel = channel; }
       )
     .def_property("version",
-      [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.version;},
-      [](DAPHNEEthFrame::Header& self, uint32_t version) {self.version = version;}
+      [](DAPHNEEthFrame::Header& self) -> uint8_t { return self.version; },
+      [](DAPHNEEthFrame::Header& self, uint8_t version) { self.version = version; }
       )
     .def_property("trigger_sample_value",
-      [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.trig_sample;},
-      [](DAPHNEEthFrame::Header& self, uint32_t trig_sample) {self.trig_sample = trig_sample;}
+      [](DAPHNEEthFrame::Header& self) -> uint16_t { return self.trig_sample; },
+      [](DAPHNEEthFrame::Header& self, uint16_t trig_sample) { self.trig_sample = trig_sample; }
       )
     .def_property("threshold",
-      [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.threshold;},
-      [](DAPHNEEthFrame::Header& self, uint32_t threshold) {self.threshold = threshold;}
+      [](DAPHNEEthFrame::Header& self) -> uint16_t { return self.threshold; },
+      [](DAPHNEEthFrame::Header& self, uint16_t threshold) { self.threshold = threshold; }
       )
     .def_property("baseline",
-      [](DAPHNEEthFrame::Header& self) -> uint32_t {return self.baseline;},
-      [](DAPHNEEthFrame::Header& self, uint32_t baseline) {self.baseline = baseline;}
+      [](DAPHNEEthFrame::Header& self) -> uint16_t { return self.baseline; },
+      [](DAPHNEEthFrame::Header& self, uint16_t baseline) { self.baseline = baseline; }
       )
-    ;
+  ;
+
+  py::class_<DAPHNEEthFrame::PeakDescriptorData>(m, "DAPHNEEthFramePeakDescriptorData")
+    .def("is_found", &DAPHNEEthFrame::PeakDescriptorData::is_found)
+    .def("set_found", &DAPHNEEthFrame::PeakDescriptorData::set_found)
+
+    .def("get_adc_integral", &DAPHNEEthFrame::PeakDescriptorData::get_adc_integral)
+    .def("set_adc_integral", &DAPHNEEthFrame::PeakDescriptorData::set_adc_integral)
+
+    .def("get_num_subpeaks", &DAPHNEEthFrame::PeakDescriptorData::get_num_subpeaks)
+    .def("set_num_subpeaks", &DAPHNEEthFrame::PeakDescriptorData::set_num_subpeaks)
+
+    .def("get_samples_over_baseline", &DAPHNEEthFrame::PeakDescriptorData::get_samples_over_baseline)
+    .def("set_samples_over_baseline", &DAPHNEEthFrame::PeakDescriptorData::set_samples_over_baseline)
+
+    .def("get_adc_max", &DAPHNEEthFrame::PeakDescriptorData::get_adc_max)
+    .def("set_adc_max", &DAPHNEEthFrame::PeakDescriptorData::set_adc_max)
+
+    .def("get_sample_max", &DAPHNEEthFrame::PeakDescriptorData::get_sample_max)
+    .def("set_sample_max", &DAPHNEEthFrame::PeakDescriptorData::set_sample_max)
+
+    .def("get_sample_start", &DAPHNEEthFrame::PeakDescriptorData::get_sample_start)
+    .def("set_sample_start", &DAPHNEEthFrame::PeakDescriptorData::set_sample_start)
+
+    .def_property("num_subpeaks_0",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint8_t { return self.num_subpeaks_0; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint8_t val) { self.num_subpeaks_0 = val; }
+      )
+    .def_property("adc_integral_0",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint32_t { return self.adc_integral_0; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint32_t val) { self.adc_integral_0 = val; }
+      )
+    .def_property("found_0",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint8_t { return self.found_0; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint8_t val) { self.found_0 = val; }
+      )
+    .def_property("adc_max_0",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint16_t { return self.adc_max_0; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint16_t val) { self.adc_max_0 = val; }
+      )
+    .def_property("sample_max_0",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint16_t { return self.sample_max_0; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint16_t val) { self.sample_max_0 = val; }
+      )
+    .def_property("samples_over_baseline_0",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint16_t { return self.samples_over_baseline_0; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint16_t val) { self.samples_over_baseline_0 = val; }
+      )
+
+    .def_property("num_subpeaks_1",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint8_t { return self.num_subpeaks_1; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint8_t val) { self.num_subpeaks_1 = val; }
+      )
+    .def_property("adc_integral_1",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint32_t { return self.adc_integral_1; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint32_t val) { self.adc_integral_1 = val; }
+      )
+    .def_property("found_1",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint8_t { return self.found_1; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint8_t val) { self.found_1 = val; }
+      )
+    .def_property("adc_max_1",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint16_t { return self.adc_max_1; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint16_t val) { self.adc_max_1 = val; }
+      )
+    .def_property("sample_max_1",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint16_t { return self.sample_max_1; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint16_t val) { self.sample_max_1 = val; }
+      )
+    .def_property("samples_over_baseline_1",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint16_t { return self.samples_over_baseline_1; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint16_t val) { self.samples_over_baseline_1 = val; }
+      )
+
+    .def_property("num_subpeaks_2",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint8_t { return self.num_subpeaks_2; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint8_t val) { self.num_subpeaks_2 = val; }
+      )
+    .def_property("adc_integral_2",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint32_t { return self.adc_integral_2; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint32_t val) { self.adc_integral_2 = val; }
+      )
+    .def_property("found_2",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint8_t { return self.found_2; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint8_t val) { self.found_2 = val; }
+      )
+    .def_property("adc_max_2",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint16_t { return self.adc_max_2; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint16_t val) { self.adc_max_2 = val; }
+      )
+    .def_property("sample_max_2",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint16_t { return self.sample_max_2; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint16_t val) { self.sample_max_2 = val; }
+      )
+    .def_property("samples_over_baseline_2",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint16_t { return self.samples_over_baseline_2; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint16_t val) { self.samples_over_baseline_2 = val; }
+      )
+
+    .def_property("num_subpeaks_3",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint8_t { return self.num_subpeaks_3; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint8_t val) { self.num_subpeaks_3 = val; }
+      )
+    .def_property("adc_integral_3",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint32_t { return self.adc_integral_3; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint32_t val) { self.adc_integral_3 = val; }
+      )
+    .def_property("found_3",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint8_t { return self.found_3; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint8_t val) { self.found_3 = val; }
+      )
+    .def_property("adc_max_3",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint16_t { return self.adc_max_3; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint16_t val) { self.adc_max_3 = val; }
+      )
+    .def_property("sample_max_3",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint16_t { return self.sample_max_3; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint16_t val) { self.sample_max_3 = val; }
+      )
+    .def_property("samples_over_baseline_3",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint16_t { return self.samples_over_baseline_3; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint16_t val) { self.samples_over_baseline_3 = val; }
+      )
+
+    .def_property("num_subpeaks_4",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint8_t { return self.num_subpeaks_4; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint8_t val) { self.num_subpeaks_4 = val; }
+      )
+    .def_property("adc_integral_4",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint32_t { return self.adc_integral_4; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint32_t val) { self.adc_integral_4 = val; }
+      )
+    .def_property("found_4",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint8_t { return self.found_4; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint8_t val) { self.found_4 = val; }
+      )
+    .def_property("adc_max_4",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint16_t { return self.adc_max_4; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint16_t val) { self.adc_max_4 = val; }
+      )
+    .def_property("sample_max_4",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint16_t { return self.sample_max_4; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint16_t val) { self.sample_max_4 = val; }
+      )
+    .def_property("samples_over_baseline_4",
+      [](DAPHNEEthFrame::PeakDescriptorData& self) -> uint16_t { return self.samples_over_baseline_4; },
+      [](DAPHNEEthFrame::PeakDescriptorData& self, uint16_t val) { self.samples_over_baseline_4 = val; }
+      )
+  ;
 
   py::class_<DAPHNEEthFrame>(m, "DAPHNEEthFrame", py::buffer_protocol())
     .def(py::init())
     .def(py::init([](py::capsule capsule) {
         auto wfp = *static_cast<DAPHNEEthFrame*>(capsule.get_pointer());
         return wfp;
-    } ))
-    .def(py::init([](py::bytes bytes){
+    }))
+    .def(py::init([](py::bytes bytes) {
         py::buffer_info info(py::buffer(bytes).request());
         auto wfp = *static_cast<DAPHNEEthFrame*>(info.ptr);
         return wfp;
     }))
-    .def("get_daqheader", [](DAPHNEEthFrame& self) -> const detdataformats::DAQEthHeader& {return self.daq_header;}, py::return_value_policy::reference_internal)
-    .def("get_daphneheader", [](DAPHNEEthFrame& self) -> const DAPHNEEthFrame::Header& {return self.header;}, py::return_value_policy::reference_internal)
-    .def("get_header", [](DAPHNEEthFrame& self) -> const DAPHNEEthFrame::Header& {return self.header;}, py::return_value_policy::reference_internal)
+    .def("get_daqheader", [](DAPHNEEthFrame& self) -> const detdataformats::DAQEthHeader& { return self.daq_header; }, py::return_value_policy::reference_internal)
+    .def("get_daphneheader", [](DAPHNEEthFrame& self) -> const DAPHNEEthFrame::Header& { return self.header; }, py::return_value_policy::reference_internal)
+    .def("get_header", [](DAPHNEEthFrame& self) -> const DAPHNEEthFrame::Header& { return self.header; }, py::return_value_policy::reference_internal)
+    .def("get_peaks_data", [](DAPHNEEthFrame& self) -> const DAPHNEEthFrame::PeakDescriptorData& { return self.get_peaks_data(); }, py::return_value_policy::reference_internal)
     .def("get_adc", &DAPHNEEthFrame::get_adc)
     .def("set_adc", &DAPHNEEthFrame::set_adc)
     .def("get_timestamp", &DAPHNEEthFrame::get_timestamp)
     .def("set_timestamp", &DAPHNEEthFrame::set_timestamp)
     .def("get_channel", &DAPHNEEthFrame::get_channel)
     .def("set_channel", &DAPHNEEthFrame::set_channel)
-    .def_static("sizeof", [](){ return sizeof(DAPHNEEthFrame); })
+    .def_static("sizeof", []() { return sizeof(DAPHNEEthFrame); })
     .def("get_bytes",
          [](DAPHNEEthFrame* fr) -> py::bytes {
            return py::bytes(reinterpret_cast<char*>(fr), sizeof(DAPHNEEthFrame));
-        })
+         })
   ;
 }
 

--- a/pybindsrc/daphneeth.cpp
+++ b/pybindsrc/daphneeth.cpp
@@ -24,6 +24,10 @@ register_daphneeth(py::module& m)
   py::class_<DAPHNEEthFrame::PeakDescriptor>(m, "DAPHNEEthFramePeakDescriptor")
 
     .def_property(
+      "found",
+      [](DAPHNEEthFrame::PeakDescriptor& self) -> bool { return self.found; },
+      [](DAPHNEEthFrame::PeakDescriptor& self, bool found) { self.found = found; })
+    .def_property(
       "num_subpeaks",
       [](DAPHNEEthFrame::PeakDescriptor& self) -> uint16_t { return self.num_subpeaks; },
       [](DAPHNEEthFrame::PeakDescriptor& self, uint16_t num_subpeaks) { self.num_subpeaks = num_subpeaks; })
@@ -96,6 +100,10 @@ register_daphneeth(py::module& m)
       "baseline",
       [](DAPHNEEthFrame::Header& self) -> uint32_t { return self.baseline; },
       [](DAPHNEEthFrame::Header& self, uint32_t baseline) { self.baseline = baseline; })
+    .def_property_readonly(
+      "peaks_data",
+      [](DAPHNEEthFrame::Header& self) -> DAPHNEEthFrame::PeakDescriptorData& { return self.peaks_data; },
+      py::return_value_policy::reference_internal)
     .def_property_readonly_static("s_expected_bytes", [](py::object /*self*/) {
       return DAPHNEEthFrame::Header::s_expected_bytes;
     });
@@ -137,6 +145,9 @@ register_daphneeth(py::module& m)
     .def("set_timestamp", &DAPHNEEthFrame::set_timestamp)
     .def("get_channel", &DAPHNEEthFrame::get_channel)
     .def("set_channel", &DAPHNEEthFrame::set_channel)
+    .def("get_peaks_data",
+       [](DAPHNEEthFrame& self) -> DAPHNEEthFrame::PeakDescriptorData& { return self.get_peaks_data(); },
+       py::return_value_policy::reference_internal)
     .def("__lt__", [](const DAPHNEEthFrame& lhs, const DAPHNEEthFrame& rhs) { return lhs < rhs; })
     .def_property_readonly_static("version", [](py::object /*self*/) { return DAPHNEEthFrame::version; })
     .def_property_readonly_static("s_bits_per_adc", [](py::object /*self*/) {
@@ -148,6 +159,9 @@ register_daphneeth(py::module& m)
     .def_property_readonly_static("s_num_adcs", [](py::object /*self*/) { return DAPHNEEthFrame::s_num_adcs; })
     .def_property_readonly_static("s_num_adc_words", [](py::object /*self*/) {
       return DAPHNEEthFrame::s_num_adc_words;
+    })
+    .def_property_readonly_static("s_max_peaks", [](py::object /*self*/) {
+      return DAPHNEEthFrame::s_max_peaks;
     })
     .def_property_readonly_static("s_expected_bytes", [](py::object /*self*/) {
       return DAPHNEEthFrame::s_expected_bytes;

--- a/scripts/DAPHNEEth_binding_test.py
+++ b/scripts/DAPHNEEth_binding_test.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python3
 
 import sys
-from fddetdataformats import DAPHNEEthFrame, DAPHNEEthHeader
+from fddetdataformats import (
+    DAPHNEEthFrame,
+    DAPHNEEthHeader,
+    DAPHNEEthFramePeakDescriptor,
+    DAPHNEEthFramePeakDescriptorData,
+)
 
 
 NUM_CHANNELS = 1
@@ -28,20 +33,38 @@ def test_static_members() -> int:
         return 1
     if DAPHNEEthFrame.s_num_adcs != ADCS_PER_CHANNEL:
         print(
-            "FAIL: DAPHNEEthFrame.s_num_adcs expected "
-            f"{ADCS_PER_CHANNEL}, got {DAPHNEEthFrame.s_num_adcs}"
+            f"FAIL: DAPHNEEthFrame.s_num_adcs expected {ADCS_PER_CHANNEL}, "
+            f"got {DAPHNEEthFrame.s_num_adcs}"
         )
         return 1
     if DAPHNEEthFrame.s_bits_per_adc != 14:
         print(f"FAIL: DAPHNEEthFrame.s_bits_per_adc expected 14, got {DAPHNEEthFrame.s_bits_per_adc}")
         return 1
     if DAPHNEEthFrame.s_expected_bytes != DAPHNEEthFrame.sizeof():
-        print(f"FAIL: DAPHNEEthFrame.s_expected_bytes {DAPHNEEthFrame.s_expected_bytes} != sizeof {DAPHNEEthFrame.sizeof()}")
+        print(
+            f"FAIL: DAPHNEEthFrame.s_expected_bytes {DAPHNEEthFrame.s_expected_bytes} "
+            f"!= sizeof {DAPHNEEthFrame.sizeof()}"
+        )
+        return 1
+    if DAPHNEEthFrame.s_max_peaks != 5:
+        print(f"FAIL: DAPHNEEthFrame.s_max_peaks expected 5, got {DAPHNEEthFrame.s_max_peaks}")
         return 1
     if DAPHNEEthHeader.s_expected_bytes <= 0:
         print(f"FAIL: DAPHNEEthHeader.s_expected_bytes invalid: {DAPHNEEthHeader.s_expected_bytes}")
         return 1
-    print("PASS: DAPHNEEthFrame/DAPHNEEthHeader static members")
+    if DAPHNEEthFramePeakDescriptor.s_expected_bytes <= 0:
+        print(
+            f"FAIL: DAPHNEEthFramePeakDescriptor.s_expected_bytes invalid: "
+            f"{DAPHNEEthFramePeakDescriptor.s_expected_bytes}"
+        )
+        return 1
+    if DAPHNEEthFramePeakDescriptorData.s_expected_bytes <= 0:
+        print(
+            f"FAIL: DAPHNEEthFramePeakDescriptorData.s_expected_bytes invalid: "
+            f"{DAPHNEEthFramePeakDescriptorData.s_expected_bytes}"
+        )
+        return 1
+    print("PASS: DAPHNEEthFrame/DAPHNEEthHeader/PeakDescriptor static members")
     return 0
 
 
@@ -133,12 +156,6 @@ def test_header_properties() -> int:
     hdr.trigger_sample_value = 123
     hdr.threshold = 456
     hdr.baseline = 789
-    hdr.w1 = 11
-    hdr.w2 = 22
-    hdr.w3 = 33
-    hdr.w4 = 44
-    hdr.w5 = 55
-    hdr.w6 = 66
 
     if hdr.channel != 5 or frame.get_channel() != 5:
         print("FAIL: header.channel mismatch")
@@ -155,14 +172,181 @@ def test_header_properties() -> int:
     if hdr.baseline != 789:
         print("FAIL: header.baseline mismatch")
         return 1
-    if (hdr.w1, hdr.w2, hdr.w3, hdr.w4, hdr.w5, hdr.w6) != (11, 22, 33, 44, 55, 66):
-        print("FAIL: w1..w6 mismatch")
+
+    peaks = hdr.peaks_data
+    if peaks is None:
+        print("FAIL: header.peaks_data returned None")
         return 1
-    if hdr_alias.w6 != 66:
-        print(f"FAIL: get_daphneheader alias mismatch, got {hdr_alias.w6}")
+    if not isinstance(peaks, DAPHNEEthFramePeakDescriptorData):
+        print(f"FAIL: header.peaks_data is not DAPHNEEthFramePeakDescriptorData, got {type(peaks)}")
         return 1
 
     print("PASS: DAPHNEEthHeader properties")
+    return 0
+
+
+def test_peaks_data_accessible() -> int:
+    frame = DAPHNEEthFrame()
+
+    peaks_via_method = frame.get_peaks_data()
+    if peaks_via_method is None:
+        print("FAIL: get_peaks_data() returned None")
+        return 1
+    if not isinstance(peaks_via_method, DAPHNEEthFramePeakDescriptorData):
+        print(f"FAIL: get_peaks_data() returned unexpected type {type(peaks_via_method)}")
+        return 1
+
+    peaks_via_header = frame.header.peaks_data
+    if peaks_via_header is None:
+        print("FAIL: header.peaks_data returned None")
+        return 1
+    if not isinstance(peaks_via_header, DAPHNEEthFramePeakDescriptorData):
+        print(f"FAIL: header.peaks_data returned unexpected type {type(peaks_via_header)}")
+        return 1
+
+    # Both paths should refer to the same underlying data
+    peaks_via_method.set_adc_integral(12345, 0)
+    if peaks_via_header.get_adc_integral(0) != 12345:
+        print("FAIL: get_peaks_data() and header.peaks_data do not alias the same data")
+        return 1
+
+    print("PASS: peaks_data accessible via get_peaks_data() and header.peaks_data")
+    return 0
+
+
+def test_peak_descriptor_data_mutators() -> int:
+    frame = DAPHNEEthFrame()
+    n_peaks = DAPHNEEthFrame.s_max_peaks
+    peaks = frame.get_peaks_data()
+
+    # Field bit widths: num_subpeaks=4, adc_integral=23, adc_max=14,
+    # sample_max=9, samples_over_baseline=9, sample_start=10
+    test_vals = [
+        dict(found=True,  num_subpeaks=i,      adc_integral=100000 + i*1000,
+             adc_max=1000 + i*100, sample_max=200 + i*10,
+             samples_over_baseline=50 + i*5, sample_start=300 + i*7)
+        for i in range(n_peaks)
+    ]
+
+    for peak, v in enumerate(test_vals):
+        peaks.set_found(v["found"], peak)
+        peaks.set_num_subpeaks(v["num_subpeaks"], peak)
+        peaks.set_adc_integral(v["adc_integral"], peak)
+        peaks.set_adc_max(v["adc_max"], peak)
+        peaks.set_sample_max(v["sample_max"], peak)
+        peaks.set_samples_over_baseline(v["samples_over_baseline"], peak)
+        peaks.set_sample_start(v["sample_start"], peak)
+
+    for peak, v in enumerate(test_vals):
+        if peaks.is_found(peak) != v["found"]:
+            print(f"FAIL: is_found({peak}) expected {v['found']}, got {peaks.is_found(peak)}")
+            return 1
+        if peaks.get_num_subpeaks(peak) != v["num_subpeaks"]:
+            print(f"FAIL: get_num_subpeaks({peak}) expected {v['num_subpeaks']}, got {peaks.get_num_subpeaks(peak)}")
+            return 1
+        if peaks.get_adc_integral(peak) != v["adc_integral"]:
+            print(f"FAIL: get_adc_integral({peak}) expected {v['adc_integral']}, got {peaks.get_adc_integral(peak)}")
+            return 1
+        if peaks.get_adc_max(peak) != v["adc_max"]:
+            print(f"FAIL: get_adc_max({peak}) expected {v['adc_max']}, got {peaks.get_adc_max(peak)}")
+            return 1
+        if peaks.get_sample_max(peak) != v["sample_max"]:
+            print(f"FAIL: get_sample_max({peak}) expected {v['sample_max']}, got {peaks.get_sample_max(peak)}")
+            return 1
+        if peaks.get_samples_over_baseline(peak) != v["samples_over_baseline"]:
+            print(f"FAIL: get_samples_over_baseline({peak}) expected {v['samples_over_baseline']}, "
+                  f"got {peaks.get_samples_over_baseline(peak)}")
+            return 1
+        if peaks.get_sample_start(peak) != v["sample_start"]:
+            print(f"FAIL: get_sample_start({peak}) expected {v['sample_start']}, got {peaks.get_sample_start(peak)}")
+            return 1
+
+    print(f"PASS: PeakDescriptorData mutators for all {n_peaks} peaks")
+    return 0
+
+
+def test_peak_descriptor_independence() -> int:
+    frame = DAPHNEEthFrame()
+    n_peaks = DAPHNEEthFrame.s_max_peaks
+    peaks = frame.get_peaks_data()
+
+    for peak in range(n_peaks):
+        peaks.set_adc_integral(peak * 111, peak)
+
+    for peak in range(n_peaks):
+        got = peaks.get_adc_integral(peak)
+        if got != peak * 111:
+            print(f"FAIL: peak independence: peak {peak} adc_integral expected {peak * 111}, got {got}")
+            return 1
+
+    print("PASS: peak descriptor fields are independent across peak indices")
+    return 0
+
+
+def test_peak_descriptor_out_of_range() -> int:
+    frame = DAPHNEEthFrame()
+    n_peaks = DAPHNEEthFrame.s_max_peaks
+    peaks = frame.get_peaks_data()
+
+    for bad_idx in (n_peaks, n_peaks + 1, -1):
+        try:
+            peaks.is_found(bad_idx)
+            print(f"FAIL: is_found({bad_idx}) should have raised an exception")
+            return 1
+        except Exception:
+            pass
+        try:
+            peaks.set_adc_integral(0, bad_idx)
+            print(f"FAIL: set_adc_integral(0, {bad_idx}) should have raised an exception")
+            return 1
+        except Exception:
+            pass
+
+    print("PASS: PeakDescriptorData out-of-range indices raise exceptions")
+    return 0
+
+
+def test_peak_data_bytes_roundtrip() -> int:
+    frame = DAPHNEEthFrame()
+    n_peaks = DAPHNEEthFrame.s_max_peaks
+    peaks = frame.get_peaks_data()
+
+    for peak in range(n_peaks):
+        peaks.set_found(True, peak)
+        peaks.set_num_subpeaks(peak, peak)
+        peaks.set_adc_integral(500000 + peak * 7777, peak)
+        peaks.set_adc_max(2000 + peak * 111, peak)
+        peaks.set_sample_max(300 + peak * 13, peak)
+        peaks.set_samples_over_baseline(100 + peak * 17, peak)
+        peaks.set_sample_start(400 + peak * 11, peak)
+
+    clone = DAPHNEEthFrame(frame.get_bytes())
+    clone_peaks = clone.get_peaks_data()
+
+    for peak in range(n_peaks):
+        if not clone_peaks.is_found(peak):
+            print(f"FAIL: bytes roundtrip: is_found({peak}) expected True")
+            return 1
+        if clone_peaks.get_num_subpeaks(peak) != peak:
+            print(f"FAIL: bytes roundtrip: get_num_subpeaks({peak})")
+            return 1
+        if clone_peaks.get_adc_integral(peak) != 500000 + peak * 7777:
+            print(f"FAIL: bytes roundtrip: get_adc_integral({peak})")
+            return 1
+        if clone_peaks.get_adc_max(peak) != 2000 + peak * 111:
+            print(f"FAIL: bytes roundtrip: get_adc_max({peak})")
+            return 1
+        if clone_peaks.get_sample_max(peak) != 300 + peak * 13:
+            print(f"FAIL: bytes roundtrip: get_sample_max({peak})")
+            return 1
+        if clone_peaks.get_samples_over_baseline(peak) != 100 + peak * 17:
+            print(f"FAIL: bytes roundtrip: get_samples_over_baseline({peak})")
+            return 1
+        if clone_peaks.get_sample_start(peak) != 400 + peak * 11:
+            print(f"FAIL: bytes roundtrip: get_sample_start({peak})")
+            return 1
+
+    print("PASS: peak descriptor data survives bytes roundtrip")
     return 0
 
 
@@ -253,6 +437,7 @@ def test_adc_out_of_range() -> int:
     print("PASS: out-of-range ADC index raises exception as expected")
     return 0
 
+
 def main() -> int:
     tests = [
         test_construction_and_size,
@@ -264,6 +449,11 @@ def main() -> int:
         test_daqheader_accessible,
         test_set_geoid,
         test_header_properties,
+        test_peaks_data_accessible,
+        test_peak_descriptor_data_mutators,
+        test_peak_descriptor_independence,
+        test_peak_descriptor_out_of_range,
+        test_peak_data_bytes_roundtrip,
         test_adc_single,
         test_adc_max_value,
         test_adc_independence,

--- a/unittest/DAPHNEEthFrame_test.cxx
+++ b/unittest/DAPHNEEthFrame_test.cxx
@@ -1,0 +1,96 @@
+/**
+ * @file DAPHNEEthFrame_test.cxx - Unit tests for DAPHNEEthFrame
+ */
+
+#include "fddetdataformats/DAPHNEEthFrame.hpp"
+
+#define BOOST_TEST_MODULE DAPHNEEthFrame_test
+
+#include "boost/test/unit_test.hpp"
+
+#include <algorithm>
+#include <random>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(DAPHNEEthFrame_test)
+
+BOOST_AUTO_TEST_CASE(DAPHNEEthFrame_AllFieldsTest)
+{
+  constexpr int n_adcs = dunedaq::fddetdataformats::DAPHNEEthFrame::s_num_adcs;
+  constexpr int n_peaks = dunedaq::fddetdataformats::DAPHNEEthFrame::PeakDescriptorData::max_peaks;
+
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<uint16_t> adc_dist(1, (1 << 14) - 1);
+  std::uniform_int_distribution<uint16_t> u10bit(0, 0x3FF);
+  std::uniform_int_distribution<uint16_t> u9bit(0, 0x1FF);
+  std::uniform_int_distribution<uint16_t> u4bit(0, 0xF);
+  std::uniform_int_distribution<uint32_t> u23bit(0, 0x7FFFFF);
+  std::uniform_int_distribution<uint16_t> u14bit(0, 0x3FFF);
+  std::uniform_int_distribution<uint8_t> u1bit(0, 1);
+
+  dunedaq::fddetdataformats::DAPHNEEthFrame frame{};
+
+  BOOST_CHECK_EQUAL(sizeof(dunedaq::fddetdataformats::DAPHNEEthFrame::PeakDescriptorData), 12 * sizeof(uint32_t));
+  BOOST_CHECK_EQUAL(sizeof(dunedaq::fddetdataformats::DAPHNEEthFrame::Header), 7 * sizeof(uint64_t));
+
+  std::vector<uint16_t> adcs(n_adcs);
+  std::generate(adcs.begin(), adcs.end(), [&]() { return adc_dist(gen); });
+
+  for (int i = 0; i < n_adcs; ++i) {
+    frame.set_adc(i, adcs[i]);
+  }
+
+  for (int i = 0; i < n_adcs; ++i) {
+    BOOST_CHECK_EQUAL(frame.get_adc(i), adcs[i]);
+  }
+
+  frame.set_channel(23);
+  frame.header.trig_sample = 0x2AAA;
+  frame.header.threshold = 0x1555;
+  frame.header.baseline = 0x0123;
+  frame.header.version = dunedaq::fddetdataformats::DAPHNEEthFrame::version;
+  frame.set_timestamp(0x123456789ABCDEF0ULL);
+
+  BOOST_CHECK_EQUAL(frame.get_channel(), 23);
+  BOOST_CHECK_EQUAL(frame.header.trig_sample, 0x2AAA);
+  BOOST_CHECK_EQUAL(frame.header.threshold, 0x1555);
+  BOOST_CHECK_EQUAL(frame.header.get_baseline(), 0x0123);
+  BOOST_CHECK_EQUAL(frame.header.version, dunedaq::fddetdataformats::DAPHNEEthFrame::version);
+  BOOST_CHECK_EQUAL(frame.get_timestamp(), 0x123456789ABCDEF0ULL);
+
+  for (int peak = 0; peak < n_peaks; ++peak) {
+    uint8_t num_subpeaks = u4bit(gen);
+    uint8_t found = u1bit(gen);
+    uint32_t adc_integral = u23bit(gen);
+    uint16_t adc_max = u14bit(gen);
+    uint16_t sample_peak = u9bit(gen);
+    uint16_t tob = u9bit(gen);
+    uint16_t sample_start = u10bit(gen);
+
+    frame.get_peaks_data().set_num_subpeaks(num_subpeaks, peak);
+    frame.get_peaks_data().set_found(found, peak);
+    frame.get_peaks_data().set_adc_integral(adc_integral, peak);
+    frame.get_peaks_data().set_adc_max(adc_max, peak);
+    frame.get_peaks_data().set_sample_max(sample_peak, peak);
+    frame.get_peaks_data().set_samples_over_baseline(tob, peak);
+    frame.get_peaks_data().set_sample_start(sample_start, peak);
+
+    BOOST_CHECK_EQUAL(frame.get_peaks_data().get_num_subpeaks(peak), num_subpeaks);
+    BOOST_CHECK_EQUAL(frame.get_peaks_data().is_found(peak), found);
+    BOOST_CHECK_EQUAL(frame.get_peaks_data().get_adc_integral(peak), adc_integral);
+    BOOST_CHECK_EQUAL(frame.get_peaks_data().get_adc_max(peak), adc_max);
+    BOOST_CHECK_EQUAL(frame.get_peaks_data().get_sample_max(peak), sample_peak);
+    BOOST_CHECK_EQUAL(frame.get_peaks_data().get_samples_over_baseline(peak), tob);
+    BOOST_CHECK_EQUAL(frame.get_peaks_data().get_sample_start(peak), sample_start);
+  }
+
+  for (int packed_word = 0; packed_word < dunedaq::fddetdataformats::DAPHNEEthFrame::s_packed_peak_descriptor_words; ++packed_word) {
+    auto value = frame.header.get_packed_peak_word(packed_word);
+    dunedaq::fddetdataformats::DAPHNEEthFrame::word_t roundtrip = 0;
+    roundtrip = value;
+    BOOST_CHECK_EQUAL(roundtrip, value);
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Description

_Otherwise, please include a summary of the change and which issue is fixed (if any).
This PR is intended to replace PRs #49 and #55 -- hopefully reconciling the changes that recently went into develop with the new peak descriptor that @marroyav describes in #49. 

Prior to merging, we need to make sure that the EDMS document with the descriptors is updated/accurate.

It also includes changes in rawdatautils (see [here](https://github.com/DUNE-DAQ/rawdatautils/pull/123)).

_Please also include instructions for how a reviewer can test your changes._
Recipe file to re-create the area here:
[wketchum_DAPHNEEth_updates_from_Manuel.yaml](https://github.com/user-attachments/files/29506496/wketchum_DAPHNEEth_updates_from_Manuel.yaml)

Unit tests all pass -- need to still verify all integration tests are working properly, but wanted this posted for review.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [x] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

Ran the `DAPHNEEth_binding_test.py` test and that all passes.

`daqsystemtest/tpstream_writing_test.py` test failed first time, but rerun and it worked, and there's no reason to expect that it shouldn't be ok ... 

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [x] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

